### PR TITLE
feat: add admin user management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Meetinity Admin Portal
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Tests
+
+```bash
+npm test
+```
+
+Set API base url via `.env`:
+
+```
+VITE_API_BASE_URL=http://localhost:5000
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,14 @@
       "name": "meetinity-admin-portal",
       "version": "1.0.0",
       "dependencies": {
+        "@tanstack/react-table": "^8.21.3",
+        "axios": "^1.11.0",
+        "chart.js": "^4.5.0",
+        "date-fns": "^4.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-chartjs-2": "^5.3.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^7.8.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "6.4.8",
@@ -947,6 +953,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1275,6 +1287,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -1988,7 +2033,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -2005,6 +2049,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2070,7 +2125,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2138,6 +2192,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -2172,7 +2238,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2187,6 +2252,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2251,6 +2325,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -2368,7 +2452,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2421,7 +2504,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2463,7 +2545,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2473,7 +2554,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2511,7 +2591,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2524,7 +2603,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2942,6 +3020,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -2979,7 +3077,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3018,7 +3115,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3038,7 +3134,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3063,7 +3158,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3173,7 +3267,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3229,7 +3322,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3242,7 +3334,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3258,7 +3349,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4007,7 +4097,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4041,7 +4130,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4051,7 +4139,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -4461,6 +4548,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -4524,6 +4617,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -4543,6 +4646,44 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
+      "integrity": "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.0.tgz",
+      "integrity": "sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -4754,6 +4895,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,14 @@
     "lint": "eslint src --ext ts,tsx"
   },
   "dependencies": {
+    "@tanstack/react-table": "^8.21.3",
+    "axios": "^1.11.0",
+    "chart.js": "^4.5.0",
+    "date-fns": "^4.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-chartjs-2": "^5.3.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^7.8.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.4.8",

--- a/src/__tests__/userComponents.test.tsx
+++ b/src/__tests__/userComponents.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { UserFilters, Filters } from '../components/UserFilters'
+import { UserActionsBar } from '../components/UserActionsBar'
+import { UserTable } from '../components/UserTable'
+import { User } from '../services/userService'
+
+it('updates search filter', () => {
+  const filters: Filters = { search: '', status: '', industry: '', startDate: '', endDate: '' }
+  const handle = vi.fn()
+  render(<UserFilters filters={filters} onChange={handle} />)
+  fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'john' } })
+  expect(handle).toHaveBeenCalledWith({ search: 'john' })
+})
+
+it('disables actions when no selection', () => {
+  const activate = vi.fn()
+  render(
+    <UserActionsBar selected={[]} onActivate={activate} onDeactivate={activate} onDelete={activate} onExport={() => {}} />
+  )
+  expect((screen.getByText('Activate') as HTMLButtonElement).disabled).toBe(true)
+})
+
+it('renders table rows', () => {
+  const data: User[] = [
+    { id: '1', name: 'A', email: 'a@a.com', status: 'active', industry: 'Tech', createdAt: '' }
+  ]
+  render(
+    <UserTable
+      data={data}
+      total={1}
+      page={0}
+      pageSize={50}
+      onPageChange={() => {}}
+      onSelect={() => {}}
+    />
+  )
+  expect(screen.getByText('a@a.com')).toBeTruthy()
+})

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,158 +1,26 @@
-import React, { useState } from 'react'
+import React from 'react'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { UserManagement } from './components/UserManagement'
 
-interface User {
-  id: number
-  name: string
-  email: string
-  status: 'active' | 'inactive'
+function AdminRoute({ children }: { children: JSX.Element }) {
+  const isAdmin = localStorage.getItem('role') === 'admin'
+  return isAdmin ? children : <div>Unauthorized</div>
 }
 
-interface Event {
-  id: number
-  title: string
-  date: string
-  attendees: number
-}
-
-function App() {
-  const [activeTab, setActiveTab] = useState<'users' | 'events' | 'analytics'>('users')
-  const [users, setUsers] = useState<User[]>([
-    { id: 1, name: 'Sophie Martin', email: 'sophie@example.com', status: 'active' },
-    { id: 2, name: 'Thomas Dubois', email: 'thomas@example.com', status: 'active' },
-    { id: 3, name: 'Marie Leroy', email: 'marie@example.com', status: 'inactive' }
-  ])
-  const [search, setSearch] = useState('')
-
-  const mockEvents: Event[] = [
-    { id: 1, title: 'Networking Night Paris', date: '2025-08-15', attendees: 45 },
-    { id: 2, title: 'Tech Meetup Lyon', date: '2025-08-20', attendees: 32 }
-  ]
-
-  const filteredUsers = users.filter(
-    u =>
-      u.name.toLowerCase().includes(search.toLowerCase()) ||
-      u.email.toLowerCase().includes(search.toLowerCase())
-  )
-  const totalUsers = users.length
-  const activeUsers = users.filter(u => u.status === 'active').length
-
-  const toggleStatus = (id: number) => {
-    setUsers(prev =>
-      prev.map(u =>
-        u.id === id ? { ...u, status: u.status === 'active' ? 'inactive' : 'active' } : u
-      )
-    )
-  }
-
-  const exportCsv = () => {
-    const header = 'id,name,email,status'
-    const rows = filteredUsers.map(u => `${u.id},${u.name},${u.email},${u.status}`)
-    const blob = new Blob([`${[header, ...rows].join('\n')}`], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'users.csv'
-    a.click()
-    URL.revokeObjectURL(url)
-  }
-
+export default function App() {
   return (
-    <div className="admin-portal">
-      <header className="header">
-        <h1>Meetinity Admin Portal</h1>
-        <p>Manage users, events, and analytics</p>
-      </header>
-
-      <nav className="nav-tabs">
-        <button
-          className={activeTab === 'users' ? 'active' : ''}
-          onClick={() => setActiveTab('users')}
-        >
-          Users ({totalUsers})
-        </button>
-        <button
-          className={activeTab === 'events' ? 'active' : ''}
-          onClick={() => setActiveTab('events')}
-        >
-          Events ({mockEvents.length})
-        </button>
-        <button
-          className={activeTab === 'analytics' ? 'active' : ''}
-          onClick={() => setActiveTab('analytics')}
-        >
-          Analytics
-        </button>
-      </nav>
-
-      <main className="content">
-        {activeTab === 'users' && (
-          <div className="users-section">
-            <h2>User Management</h2>
-            <div className="user-controls">
-              <input
-                type="text"
-                placeholder="Search users..."
-                value={search}
-                onChange={e => setSearch(e.target.value)}
-              />
-              <button onClick={exportCsv}>Export CSV</button>
-            </div>
-            <div className="user-stats">
-              <span>Total: {totalUsers}</span>
-              <span>Active: {activeUsers}</span>
-            </div>
-            <div className="user-list">
-              {filteredUsers.map(user => (
-                <div key={user.id} className="user-card">
-                  <h3>{user.name}</h3>
-                  <p>{user.email}</p>
-                  <span className={`status ${user.status}`}>{user.status}</span>
-                  <button onClick={() => toggleStatus(user.id)}>
-                    {user.status === 'active' ? 'Deactivate' : 'Activate'}
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {activeTab === 'events' && (
-          <div className="events-section">
-            <h2>Event Management</h2>
-            <div className="event-list">
-              {mockEvents.map(event => (
-                <div key={event.id} className="event-card">
-                  <h3>{event.title}</h3>
-                  <p>Date: {event.date}</p>
-                  <p>Attendees: {event.attendees}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {activeTab === 'analytics' && (
-          <div className="analytics-section">
-            <h2>Analytics Dashboard</h2>
-            <div className="stats-grid">
-              <div className="stat-card">
-                <h3>Total Users</h3>
-                <p className="stat-number">{totalUsers}</p>
-              </div>
-              <div className="stat-card">
-                <h3>Active Events</h3>
-                <p className="stat-number">{mockEvents.length}</p>
-              </div>
-              <div className="stat-card">
-                <h3>Total Matches</h3>
-                <p className="stat-number">127</p>
-              </div>
-            </div>
-          </div>
-        )}
-      </main>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route
+          path="/admin/users"
+          element={
+            <AdminRoute>
+              <UserManagement />
+            </AdminRoute>
+          }
+        />
+        <Route path="*" element={<Navigate to="/admin/users" replace />} />
+      </Routes>
+    </BrowserRouter>
   )
 }
-
-export default App

--- a/src/components/UserActionsBar.tsx
+++ b/src/components/UserActionsBar.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+interface Props {
+  selected: string[]
+  onActivate: () => void
+  onDeactivate: () => void
+  onDelete: () => void
+  onExport: () => void
+}
+
+export function UserActionsBar({ selected, onActivate, onDeactivate, onDelete, onExport }: Props) {
+  const disabled = selected.length === 0
+  return (
+    <div className="user-actions">
+      <button disabled={disabled} onClick={onActivate}>Activate</button>
+      <button disabled={disabled} onClick={onDeactivate}>Deactivate</button>
+      <button disabled={disabled} onClick={onDelete}>Delete</button>
+      <button onClick={onExport}>Export CSV</button>
+    </div>
+  )
+}

--- a/src/components/UserFilters.tsx
+++ b/src/components/UserFilters.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+export interface Filters {
+  search: string
+  status: string
+  industry: string
+  startDate: string
+  endDate: string
+}
+
+interface Props {
+  filters: Filters
+  onChange: (f: Partial<Filters>) => void
+}
+
+export function UserFilters({ filters, onChange }: Props) {
+  return (
+    <div className="user-filters">
+      <input
+        placeholder="Search"
+        value={filters.search}
+        onChange={e => onChange({ search: e.target.value })}
+      />
+      <select
+        value={filters.status}
+        onChange={e => onChange({ status: e.target.value })}
+      >
+        <option value="">All Status</option>
+        <option value="active">Active</option>
+        <option value="inactive">Inactive</option>
+      </select>
+      <select
+        value={filters.industry}
+        onChange={e => onChange({ industry: e.target.value })}
+      >
+        <option value="">All Industries</option>
+        <option value="Tech">Tech</option>
+        <option value="Finance">Finance</option>
+        <option value="Other">Other</option>
+      </select>
+      <input
+        type="date"
+        value={filters.startDate}
+        onChange={e => onChange({ startDate: e.target.value })}
+      />
+      <input
+        type="date"
+        value={filters.endDate}
+        onChange={e => onChange({ endDate: e.target.value })}
+      />
+    </div>
+  )
+}

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react'
+import { User, UserService } from '../services/userService'
+import { UserFilters, Filters } from './UserFilters'
+import { UserTable } from './UserTable'
+import { UserActionsBar } from './UserActionsBar'
+import { UserStats } from './UserStats'
+import { useDebounce } from '../hooks/useDebounce'
+import { usePagination } from '../hooks/usePagination'
+import { downloadCsv } from '../utils/csv'
+
+export function UserManagement() {
+  const [users, setUsers] = useState<User[]>([])
+  const [total, setTotal] = useState(0)
+  const [stats, setStats] = useState({ signups: {}, byIndustry: {}, byStatus: {} })
+  const [selected, setSelected] = useState<string[]>([])
+  const [filters, setFilters] = useState<Filters>({
+    search: '',
+    status: '',
+    industry: '',
+    startDate: '',
+    endDate: ''
+  })
+
+  const debouncedSearch = useDebounce(filters.search)
+  const { page, pageSize, setPage } = usePagination(50)
+
+  const loadUsers = async () => {
+    const res = await UserService.list({
+      page,
+      pageSize,
+      search: debouncedSearch,
+      status: filters.status,
+      industry: filters.industry,
+      startDate: filters.startDate,
+      endDate: filters.endDate
+    })
+    setUsers(res.users)
+    setTotal(res.total)
+  }
+
+  const loadStats = async () => {
+    const data = await UserService.stats()
+    setStats(data)
+  }
+
+  useEffect(() => {
+    loadUsers()
+  }, [page, debouncedSearch, filters.status, filters.industry, filters.startDate, filters.endDate])
+
+  useEffect(() => {
+    loadStats()
+  }, [])
+
+  const handleAction = async (action: 'activate' | 'deactivate' | 'delete') => {
+    await UserService.bulk(selected, action)
+    setSelected([])
+    loadUsers()
+  }
+
+  const handleExport = async () => {
+    const blob = await UserService.export({
+      search: debouncedSearch,
+      status: filters.status,
+      industry: filters.industry,
+      startDate: filters.startDate,
+      endDate: filters.endDate
+    })
+    downloadCsv(blob, 'users.csv')
+  }
+
+  return (
+    <div>
+      <UserFilters filters={filters} onChange={f => { setFilters(prev => ({ ...prev, ...f })); setPage(0) }} />
+      <UserActionsBar
+        selected={selected}
+        onActivate={() => handleAction('activate')}
+        onDeactivate={() => handleAction('deactivate')}
+        onDelete={() => handleAction('delete')}
+        onExport={handleExport}
+      />
+      <UserTable
+        data={users}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={setPage}
+        onSelect={setSelected}
+      />
+      <UserStats stats={stats} />
+    </div>
+  )
+}

--- a/src/components/UserStats.tsx
+++ b/src/components/UserStats.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  ArcElement,
+  LineElement,
+  PointElement
+} from 'chart.js'
+import { Bar, Pie, Line } from 'react-chartjs-2'
+import { Stats } from '../services/userService'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, ArcElement, LineElement, PointElement)
+
+interface Props {
+  stats: Stats
+}
+
+export function UserStats({ stats }: Props) {
+  const signupData = {
+    labels: Object.keys(stats.signups),
+    datasets: [
+      {
+        label: 'Signups',
+        data: Object.values(stats.signups),
+        borderColor: 'rgba(75,192,192,1)'
+      }
+    ]
+  }
+
+  const industryData = {
+    labels: Object.keys(stats.byIndustry),
+    datasets: [
+      {
+        label: 'Industry',
+        data: Object.values(stats.byIndustry),
+        backgroundColor: ['#36a2eb', '#ff6384', '#ffcd56', '#4bc0c0']
+      }
+    ]
+  }
+
+  const statusData = {
+    labels: Object.keys(stats.byStatus),
+    datasets: [
+      {
+        label: 'Status',
+        data: Object.values(stats.byStatus),
+        backgroundColor: ['#4caf50', '#f44336']
+      }
+    ]
+  }
+
+  return (
+    <div className="user-stats">
+      <div className="chart">
+        <Line data={signupData} />
+      </div>
+      <div className="chart">
+        <Bar data={industryData} />
+      </div>
+      <div className="chart">
+        <Pie data={statusData} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import {
+  useReactTable,
+  ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  flexRender
+} from '@tanstack/react-table'
+import { User } from '../services/userService'
+
+interface Props {
+  data: User[]
+  total: number
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onSelect: (ids: string[]) => void
+}
+
+export function UserTable({ data, total, page, pageSize, onPageChange, onSelect }: Props) {
+  const [rowSelection, setRowSelection] = React.useState({})
+
+  const columns = React.useMemo<ColumnDef<User>[]>(
+    () => [
+      {
+        id: 'select',
+        header: ({ table }) => (
+          <input
+            type="checkbox"
+            checked={table.getIsAllPageRowsSelected()}
+            onChange={table.getToggleAllPageRowsSelectedHandler()}
+          />
+        ),
+        cell: ({ row }) => (
+          <input
+            type="checkbox"
+            checked={row.getIsSelected()}
+            disabled={!row.getCanSelect()}
+            onChange={row.getToggleSelectedHandler()}
+          />
+        )
+      },
+      { accessorKey: 'name', header: 'Name' },
+      { accessorKey: 'email', header: 'Email' },
+      { accessorKey: 'status', header: 'Status' },
+      { accessorKey: 'industry', header: 'Industry' },
+      { accessorKey: 'createdAt', header: 'Created' }
+    ],
+    []
+  )
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { rowSelection },
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel()
+  })
+
+  React.useEffect(() => {
+    onSelect(Object.keys(rowSelection))
+  }, [rowSelection, onSelect])
+
+  const pageCount = Math.ceil(total / pageSize)
+
+  return (
+    <div className="user-table">
+      <table>
+        <thead>
+          {table.getHeaderGroups().map(hg => (
+            <tr key={hg.id}>
+              {hg.headers.map(h => (
+                <th key={h.id} onClick={h.column.getToggleSortingHandler() as any}>
+                  {flexRender(h.column.columnDef.header, h.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map(row => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="pagination">
+        <button disabled={page === 0} onClick={() => onPageChange(page - 1)}>
+          Prev
+        </button>
+        <span>
+          Page {page + 1} / {pageCount}
+        </span>
+        <button disabled={page + 1 >= pageCount} onClick={() => onPageChange(page + 1)}>
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react'
+
+export function useDebounce<T>(value: T, delay = 300) {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+  return debounced
+}

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,9 @@
+import { useState } from 'react'
+
+export function usePagination(pageSize = 50) {
+  const [page, setPage] = useState(0)
+  const next = () => setPage(p => p + 1)
+  const prev = () => setPage(p => Math.max(0, p - 1))
+  const reset = () => setPage(0)
+  return { page, pageSize, next, prev, reset, setPage }
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,56 @@
+import axios from 'axios'
+
+export interface User {
+  id: string
+  name: string
+  email: string
+  status: string
+  industry?: string
+  createdAt?: string
+}
+
+const API = import.meta.env.VITE_API_BASE_URL
+
+export interface ListParams {
+  page?: number
+  pageSize?: number
+  search?: string
+  status?: string
+  industry?: string
+  startDate?: string
+  endDate?: string
+}
+
+export interface Stats {
+  signups: Record<string, number>
+  byIndustry: Record<string, number>
+  byStatus: Record<string, number>
+}
+
+export const UserService = {
+  async list(params: ListParams) {
+    const { data } = await axios.get(`${API}/api/users`, { params })
+    return data as { users: User[]; total: number }
+  },
+  async update(id: string, payload: Partial<User>) {
+    const { data } = await axios.put(`${API}/api/users/${id}`, payload)
+    return data as User
+  },
+  async remove(id: string) {
+    await axios.delete(`${API}/api/users/${id}`)
+  },
+  async bulk(ids: string[], action: 'activate' | 'deactivate' | 'delete') {
+    await axios.post(`${API}/api/users/bulk`, { ids, action })
+  },
+  async stats() {
+    const { data } = await axios.get(`${API}/api/users/stats`)
+    return data as Stats
+  },
+  async export(params: ListParams) {
+    const res = await axios.get(`${API}/api/users/export`, {
+      params,
+      responseType: 'blob'
+    })
+    return res.data as Blob
+  }
+}

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,8 @@
+export function downloadCsv(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
- add admin users route with guard
- implement user management dashboard with filters, table, stats, and actions
- add CSV export utility, hooks, and basic tests

## Testing
- `node node_modules/vitest/vitest.mjs run --environment jsdom`

------
https://chatgpt.com/codex/tasks/task_e_689b653b50308332889e3f07d3a54b07