### PR TITLE
Update user selection to use data identifiers

### DIFF
--- a/src/__tests__/userComponents.test.tsx
+++ b/src/__tests__/userComponents.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { UserFilters, Filters } from '../components/UserFilters'
 import { UserActionsBar } from '../components/UserActionsBar'
@@ -37,4 +38,29 @@ it('renders table rows', () => {
     />
   )
   expect(screen.getByText('a@a.com')).toBeTruthy()
+})
+
+it('passes selected user ids to onSelect', async () => {
+  const data: User[] = [
+    { id: 'user-1', name: 'A', email: 'a@a.com', status: 'active', industry: 'Tech', createdAt: '' }
+  ]
+  const onSelect = vi.fn()
+
+  const view = render(
+    <UserTable
+      data={data}
+      total={1}
+      page={0}
+      pageSize={50}
+      onPageChange={() => {}}
+      onSelect={onSelect}
+    />
+  )
+
+  const [, rowCheckbox] = within(view.container).getAllByRole('checkbox')
+  await userEvent.click(rowCheckbox)
+
+  await waitFor(() => {
+    expect(onSelect).toHaveBeenCalledWith(['user-1'])
+  })
 })

--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -56,12 +56,13 @@ export function UserTable({ data, total, page, pageSize, onPageChange, onSelect 
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel()
+    getSortedRowModel: getSortedRowModel(),
+    getRowId: row => row.id
   })
 
   React.useEffect(() => {
-    onSelect(Object.keys(rowSelection))
-  }, [rowSelection, onSelect])
+    onSelect(table.getSelectedRowModel().rows.map(row => row.original.id))
+  }, [rowSelection, onSelect, table])
 
   const pageCount = Math.ceil(total / pageSize)
 


### PR DESCRIPTION
## Summary
- ensure the user table hands the business IDs to the selection model by wiring `getRowId`
- propagate selected IDs from the table’s row model when notifying `onSelect`
- add a regression test that selects a row and asserts the emitted IDs match the data

## Testing
- npm test -- --run --environment jsdom userComponents

------
https://chatgpt.com/codex/tasks/task_e_68d78ac17cac8332a5b14f2173e17ad1