### PR TITLE
Use immediate search filter for user export

### DIFF
--- a/src/__tests__/userComponents.test.tsx
+++ b/src/__tests__/userComponents.test.tsx
@@ -1,10 +1,30 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('../services/userService', () => ({
+  UserService: {
+    list: vi.fn().mockResolvedValue({ users: [], total: 0 }),
+    stats: vi.fn().mockResolvedValue({ signups: {}, byIndustry: {}, byStatus: {} }),
+    export: vi.fn().mockResolvedValue(new Blob()),
+    bulk: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
+vi.mock('../utils/csv', () => ({
+  downloadCsv: vi.fn()
+}))
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
 import { UserFilters, Filters } from '../components/UserFilters'
 import { UserActionsBar } from '../components/UserActionsBar'
 import { UserTable } from '../components/UserTable'
-import { User } from '../services/userService'
+import { UserManagement } from '../components/UserManagement'
+import type { User } from '../services/userService'
+import { UserService } from '../services/userService'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
 
 it('updates search filter', () => {
   const filters: Filters = { search: '', status: '', industry: '', startDate: '', endDate: '' }
@@ -37,4 +57,27 @@ it('renders table rows', () => {
     />
   )
   expect(screen.getByText('a@a.com')).toBeTruthy()
+})
+
+it('uses the current search input when exporting users', async () => {
+  render(<UserManagement />)
+
+  await waitFor(() => expect(UserService.list).toHaveBeenCalled())
+
+  const searchInput = screen.getByPlaceholderText('Search') as HTMLInputElement
+  fireEvent.change(searchInput, { target: { value: 'urgent' } })
+
+  await waitFor(() => expect(searchInput.value).toBe('urgent'))
+
+  fireEvent.click(screen.getByText('Export CSV'))
+
+  await waitFor(() => expect(UserService.export).toHaveBeenCalled())
+
+  expect(UserService.export).toHaveBeenLastCalledWith({
+    search: 'urgent',
+    status: '',
+    industry: '',
+    startDate: '',
+    endDate: ''
+  })
 })

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -59,7 +59,7 @@ export function UserManagement() {
 
   const handleExport = async () => {
     const blob = await UserService.export({
-      search: debouncedSearch,
+      search: filters.search,
       status: filters.status,
       industry: filters.industry,
       startDate: filters.startDate,


### PR DESCRIPTION
## Summary
- update the user export request to use the current search filter value
- add a unit test verifying that export uses the immediate search input and mock dependencies

## Testing
- npm test *(fails: vitest Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68d78ac29fc083329d8034dd1fb4d816