### PR TITLE
Ensure bulk actions refresh user stats

### DIFF
--- a/src/__tests__/userComponents.test.tsx
+++ b/src/__tests__/userComponents.test.tsx
@@ -78,6 +78,8 @@ it('clears selection in table after bulk action', async () => {
 
   await waitFor(() => expect(UserService.bulk).toHaveBeenCalledWith(['1'], 'deactivate'))
 
+  await waitFor(() => expect(UserService.stats).toHaveBeenCalledTimes(2))
+
   await waitFor(() => expect(getRowCheckbox()).not.toBeChecked())
 })
 

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -56,7 +56,12 @@ export function UserManagement() {
     await UserService.bulk(selected, action)
     setSelected([])
     setSelectionResetKey(prev => prev + 1)
-    loadUsers()
+    await loadUsers()
+    try {
+      await loadStats()
+    } catch (error) {
+      console.error('Failed to refresh user stats', error)
+    }
   }
 
   const handleExport = async () => {


### PR DESCRIPTION
## Summary
- refresh both user listings and statistics after bulk actions in the user management view
- protect the statistics refresh so UI interactions continue if the stats call fails
- extend the user component tests to confirm that bulk actions trigger a stats reload

## Testing
- npm test *(fails: document is not defined because Vitest is not configured with a browser-like environment in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d966ad02ec8332b246c4bb9cc1286f