### PR TITLE
Handle empty pagination state in user table

### DIFF
--- a/src/__tests__/userComponents.test.tsx
+++ b/src/__tests__/userComponents.test.tsx
@@ -59,6 +59,33 @@ it('renders table rows', () => {
   expect(screen.getByText('a@a.com')).toBeTruthy()
 })
 
+it('disables pagination when there are no users', () => {
+  const onPageChange = vi.fn()
+  render(
+    <UserTable
+      data={[]}
+      total={0}
+      page={0}
+      pageSize={50}
+      onPageChange={onPageChange}
+      onSelect={() => {}}
+    />
+  )
+
+  expect(screen.getByText('No pages available')).toBeInTheDocument()
+
+  const prevButton = screen.getByText('Prev') as HTMLButtonElement
+  const nextButton = screen.getByText('Next') as HTMLButtonElement
+
+  expect(prevButton).toBeDisabled()
+  expect(nextButton).toBeDisabled()
+
+  fireEvent.click(prevButton)
+  fireEvent.click(nextButton)
+
+  expect(onPageChange).not.toHaveBeenCalled()
+})
+
 it('clears selection in table after bulk action', async () => {
   const users: User[] = [
     { id: '1', name: 'Alice', email: 'alice@example.com', status: 'active', industry: 'Tech', createdAt: '' }

--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -79,7 +79,11 @@ export function UserTable({
     onSelect(table.getSelectedRowModel().rows.map(row => row.original.id))
   }, [rowSelection, onSelect, table])
 
-  const pageCount = Math.ceil(total / pageSize)
+  const safePageSize = pageSize > 0 ? pageSize : 1
+  const pageCount = Math.max(1, Math.ceil(total / safePageSize))
+  const hasPages = total > 0
+  const canGoPrev = hasPages && page > 0
+  const canGoNext = hasPages && page + 1 < pageCount
 
   return (
     <div className="user-table">
@@ -106,13 +110,31 @@ export function UserTable({
         </tbody>
       </table>
       <div className="pagination">
-        <button disabled={page === 0} onClick={() => onPageChange(page - 1)}>
+        <button
+          disabled={!canGoPrev}
+          onClick={() => {
+            if (canGoPrev) {
+              onPageChange(page - 1)
+            }
+          }}
+        >
           Prev
         </button>
         <span>
-          Page {page + 1} / {pageCount}
+          {hasPages ? (
+            <>Page {page + 1} / {pageCount}</>
+          ) : (
+            'No pages available'
+          )}
         </span>
-        <button disabled={page + 1 >= pageCount} onClick={() => onPageChange(page + 1)}>
+        <button
+          disabled={!canGoNext}
+          onClick={() => {
+            if (canGoNext) {
+              onPageChange(page + 1)
+            }
+          }}
+        >
           Next
         </button>
       </div>


### PR DESCRIPTION
## Summary
- guard the user table pagination calculations against invalid sizes and empty datasets
- disable pagination navigation when there is nothing to paginate and show a clear "No pages available" message
- cover the empty-pagination scenario with a unit test

## Testing
- npm test -- --runInBand *(fails: vitest: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68d967c18c088332bd8420f914aface8