### PR TITLE
Adjust pagination after total changes

### DIFF
--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -37,6 +37,7 @@ export function UserManagement() {
     })
     setUsers(res.users)
     setTotal(res.total)
+    return res
   }
 
   const loadStats = async () => {
@@ -45,8 +46,16 @@ export function UserManagement() {
   }
 
   useEffect(() => {
-    loadUsers()
-  }, [page, debouncedSearch, filters.status, filters.industry, filters.startDate, filters.endDate])
+    const refresh = async () => {
+      const res = await loadUsers()
+      const maxPage = Math.max(0, Math.ceil(res.total / pageSize) - 1)
+      if (page > maxPage) {
+        setPage(maxPage)
+      }
+    }
+
+    refresh()
+  }, [page, debouncedSearch, filters.status, filters.industry, filters.startDate, filters.endDate, pageSize, setPage])
 
   useEffect(() => {
     loadStats()
@@ -56,7 +65,11 @@ export function UserManagement() {
     await UserService.bulk(selected, action)
     setSelected([])
     setSelectionResetKey(prev => prev + 1)
-    await loadUsers()
+    const res = await loadUsers()
+    const maxPage = Math.max(0, Math.ceil(res.total / pageSize) - 1)
+    if (page > maxPage) {
+      setPage(maxPage)
+    }
     try {
       await loadStats()
     } catch (error) {


### PR DESCRIPTION
## Summary
- update user management loader to return metadata and clamp the current page when totals shrink
- apply the same pagination correction during automatic reloads and mock chart rendering in tests
- add a regression test covering deletion-driven total decreases and page correction

## Testing
- npm test -- --environment jsdom userComponents

------
https://chatgpt.com/codex/tasks/task_e_68d96e7704f083329d63bce976a4b58f