### PR TITLE
feat: add admin auth guard and layout

### DIFF
--- a/src/__tests__/authRouting.test.tsx
+++ b/src/__tests__/authRouting.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import App from '../app'
+import { AuthService } from '../services/authService'
+
+vi.mock('../services/authService', () => ({
+  AuthService: {
+    getSession: vi.fn(),
+    getPermissions: vi.fn()
+  }
+}))
+
+const mockedAuthService = vi.mocked(AuthService, true)
+
+describe('Auth routing guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.pushState({}, '', '/')
+  })
+
+  it('affiche un état de chargement pendant la récupération des permissions', () => {
+    mockedAuthService.getSession.mockReturnValue(new Promise(() => {}))
+    mockedAuthService.getPermissions.mockReturnValue(new Promise(() => {}))
+
+    const { unmount } = render(<App />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Chargement des permissions...')
+
+    unmount()
+  })
+
+  it('autorise l’accès lorsque les permissions requises sont présentes', async () => {
+    window.history.pushState({}, '', '/admin/users')
+
+    mockedAuthService.getSession.mockResolvedValue({
+      id: '1',
+      email: 'admin@example.com',
+      name: 'Admin Example',
+      role: 'super-admin'
+    })
+
+    mockedAuthService.getPermissions.mockResolvedValue({
+      permissions: ['admin:access', 'users:read'],
+      roles: ['super-admin']
+    })
+
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByText('Export CSV')).toBeInTheDocument())
+  })
+
+  it('redirige vers /unauthorized lorsque les permissions sont insuffisantes', async () => {
+    window.history.pushState({}, '', '/admin/events')
+
+    mockedAuthService.getSession.mockResolvedValue({
+      id: '1',
+      email: 'admin@example.com',
+      name: 'Admin Example',
+      role: 'super-admin'
+    })
+
+    mockedAuthService.getPermissions.mockResolvedValue({
+      permissions: ['admin:access', 'users:read'],
+      roles: ['super-admin']
+    })
+
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByText('Accès refusé')).toBeInTheDocument())
+    expect(window.location.pathname).toBe('/unauthorized')
+  })
+})

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,26 +1,104 @@
 import React from 'react'
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { UserManagement } from './components/UserManagement'
+import { AuthProvider, usePermissions } from './hooks/usePermissions'
+import { AdminLayout } from './components/layout/AdminLayout'
+import { ADMIN_MODULES } from './utils/adminNavigation'
 
-function AdminRoute({ children }: { children: JSX.Element }) {
-  const isAdmin = localStorage.getItem('role') === 'admin'
-  return isAdmin ? children : <div>Unauthorized</div>
+interface RequirePermissionsProps {
+  requiredPermissions?: string[]
+  children: React.ReactElement
+}
+
+function RequirePermissions({ children, requiredPermissions = [] }: RequirePermissionsProps) {
+  const { isLoading, error, hasPermissions } = usePermissions()
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        style={{ padding: '48px', textAlign: 'center', fontSize: '1rem' }}
+      >
+        Chargement des permissions...
+      </div>
+    )
+  }
+
+  if (error) {
+    return <Navigate to="/unauthorized" replace state={{ message: error }} />
+  }
+
+  if (!hasPermissions(requiredPermissions)) {
+    return <Navigate to="/unauthorized" replace />
+  }
+
+  return children
+}
+
+function UnauthorizedPage() {
+  const location = useLocation<{ message?: string }>()
+  const message = location.state?.message
+
+  return (
+    <section style={{ padding: '64px', textAlign: 'center' }}>
+      <h1 style={{ fontSize: '2rem', marginBottom: '16px' }}>Accès refusé</h1>
+      <p style={{ marginBottom: '16px' }}>
+        {message || "Vous n'avez pas accès à cette section de l'espace d'administration."}
+      </p>
+      <a href="/admin" style={{ color: '#2563eb', textDecoration: 'underline' }}>
+        Retourner au tableau de bord
+      </a>
+    </section>
+  )
+}
+
+function ModulePlaceholder({ title, description }: { title: string; description?: string }) {
+  return (
+    <section>
+      <h2 style={{ fontSize: '1.5rem', marginBottom: '12px' }}>{title}</h2>
+      {description && <p style={{ marginBottom: '12px', color: '#4b5563' }}>{description}</p>}
+      <p style={{ color: '#6b7280' }}>Le module sera disponible prochainement.</p>
+    </section>
+  )
 }
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route
-          path="/admin/users"
-          element={
-            <AdminRoute>
-              <UserManagement />
-            </AdminRoute>
-          }
-        />
-        <Route path="*" element={<Navigate to="/admin/users" replace />} />
-      </Routes>
+      <AuthProvider>
+        <Routes>
+          <Route
+            path="/admin"
+            element={
+              <RequirePermissions requiredPermissions={['admin:access']}>
+                <AdminLayout />
+              </RequirePermissions>
+            }
+          >
+            <Route index element={<Navigate to="users" replace />} />
+            {ADMIN_MODULES.map(module => (
+              <Route
+                key={module.path}
+                path={module.path}
+                element={
+                  <RequirePermissions
+                    requiredPermissions={['admin:access', ...module.requiredPermissions]}
+                  >
+                    {module.path === 'users' ? (
+                      <UserManagement />
+                    ) : (
+                      <ModulePlaceholder title={module.label} description={module.description} />
+                    )}
+                  </RequirePermissions>
+                }
+              />
+            ))}
+          </Route>
+          <Route path="/unauthorized" element={<UnauthorizedPage />} />
+          <Route path="*" element={<Navigate to="/admin" replace />} />
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   )
 }

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,132 @@
+import React, { useMemo } from 'react'
+import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { usePermissions } from '../../hooks/usePermissions'
+import { ADMIN_MODULES } from '../../utils/adminNavigation'
+
+const layoutStyle: React.CSSProperties = {
+  display: 'flex',
+  minHeight: '100vh',
+  backgroundColor: '#f3f4f6'
+}
+
+const sidebarStyle: React.CSSProperties = {
+  width: '260px',
+  backgroundColor: '#111827',
+  color: '#fff',
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '24px 16px',
+  boxSizing: 'border-box'
+}
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '16px 24px',
+  backgroundColor: '#fff',
+  borderBottom: '1px solid #e5e7eb'
+}
+
+const mainStyle: React.CSSProperties = {
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column'
+}
+
+const contentStyle: React.CSSProperties = {
+  padding: '24px',
+  flex: 1
+}
+
+const navLinkBaseStyle: React.CSSProperties = {
+  color: '#e5e7eb',
+  padding: '10px 14px',
+  borderRadius: '8px',
+  textDecoration: 'none',
+  fontWeight: 500,
+  marginBottom: '6px',
+  display: 'block'
+}
+
+const navLinkActiveStyle: React.CSSProperties = {
+  ...navLinkBaseStyle,
+  backgroundColor: '#1f2937',
+  color: '#fff'
+}
+
+const breadcrumbNavStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: '0.875rem',
+  color: '#6b7280'
+}
+
+export function AdminLayout() {
+  const location = useLocation()
+  const { admin } = usePermissions()
+
+  const labelMap = useMemo(() => {
+    const map = new Map<string, string>()
+    map.set('admin', 'Administration')
+    ADMIN_MODULES.forEach(module => {
+      map.set(module.path, module.label)
+    })
+    return map
+  }, [])
+
+  const breadcrumbs = useMemo(() => {
+    const segments = location.pathname.split('/').filter(Boolean)
+    let currentPath = ''
+
+    return segments.map(segment => {
+      currentPath += `/${segment}`
+      const label = labelMap.get(segment) || segment
+      return { path: currentPath, label }
+    })
+  }, [labelMap, location.pathname])
+
+  return (
+    <div style={layoutStyle}>
+      <aside style={sidebarStyle}>
+        <div style={{ marginBottom: '32px' }}>
+          <span style={{ fontSize: '1.25rem', fontWeight: 700 }}>Meetinity Admin</span>
+        </div>
+        <nav aria-label="Navigation principale">
+          {ADMIN_MODULES.map(module => (
+            <NavLink
+              key={module.path}
+              to={`/admin/${module.path}`}
+              style={({ isActive }) => (isActive ? navLinkActiveStyle : navLinkBaseStyle)}
+            >
+              <div style={{ fontWeight: 600 }}>{module.label}</div>
+              <div style={{ fontSize: '0.75rem', color: '#9ca3af' }}>{module.description}</div>
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+      <div style={mainStyle}>
+        <header style={headerStyle}>
+          <div>
+            <h1 style={{ margin: 0, fontSize: '1.5rem' }}>Tableau de bord</h1>
+            <nav aria-label="Fil d'Ariane" style={breadcrumbNavStyle}>
+              {breadcrumbs.map((crumb, index) => (
+                <React.Fragment key={crumb.path}>
+                  {index > 0 && <span style={{ margin: '0 8px' }}>/</span>}
+                  <span>{crumb.label}</span>
+                </React.Fragment>
+              ))}
+            </nav>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontWeight: 600 }}>{admin?.name || 'Administrateur'}</div>
+            <div style={{ fontSize: '0.875rem', color: '#6b7280' }}>{admin?.email}</div>
+          </div>
+        </header>
+        <main style={contentStyle}>
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,0 +1,102 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
+import { AuthService, AuthServiceError, AdminSession } from '../services/authService'
+
+interface AuthContextValue {
+  admin: AdminSession | null
+  permissions: string[]
+  roles: string[]
+  isLoading: boolean
+  error: string | null
+  hasPermissions: (required?: string[]) => boolean
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [admin, setAdmin] = useState<AdminSession | null>(null)
+  const [permissions, setPermissions] = useState<string[]>([])
+  const [roles, setRoles] = useState<string[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const load = async () => {
+      try {
+        const [session, permissionsResponse] = await Promise.all([
+          AuthService.getSession(),
+          AuthService.getPermissions()
+        ])
+
+        if (!isMounted) {
+          return
+        }
+
+        if (!session || !permissionsResponse) {
+          throw new AuthServiceError('Session administrateur invalide.')
+        }
+
+        setAdmin(session)
+        setPermissions(permissionsResponse.permissions || [])
+        setRoles(permissionsResponse.roles || [])
+        setError(null)
+      } catch (err) {
+        if (!isMounted) {
+          return
+        }
+
+        const message = err instanceof AuthServiceError ? err.message : 'Accès refusé.'
+        setAdmin(null)
+        setPermissions([])
+        setRoles([])
+        setError(message)
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    load()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const hasPermissions = useCallback(
+    (required?: string[]) => {
+      if (!required || required.length === 0) {
+        return true
+      }
+
+      return required.every(permission => permissions.includes(permission))
+    },
+    [permissions]
+  )
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ admin, permissions, roles, isLoading, error, hasPermissions }),
+    [admin, permissions, roles, isLoading, error, hasPermissions]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export const usePermissions = () => {
+  const context = useContext(AuthContext)
+
+  if (!context) {
+    throw new Error('usePermissions doit être utilisé dans un AuthProvider')
+  }
+
+  return context
+}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,60 @@
+import axios, { AxiosError } from 'axios'
+
+const API = import.meta.env.VITE_API_BASE_URL
+
+export interface AdminSession {
+  id: string
+  email: string
+  name: string
+  role: string
+}
+
+export interface AdminPermissionsResponse {
+  permissions: string[]
+  roles?: string[]
+}
+
+export class AuthServiceError extends Error {
+  constructor(message: string, public status?: number) {
+    super(message)
+    this.name = 'AuthServiceError'
+  }
+}
+
+const normalizeError = (error: unknown): never => {
+  if (axios.isAxiosError(error)) {
+    const axiosError = error as AxiosError<{ message?: string }>
+    const message =
+      axiosError.response?.data?.message ||
+      axiosError.message ||
+      'Une erreur est survenue lors de la vérification de la session.'
+
+    throw new AuthServiceError(message, axiosError.response?.status)
+  }
+
+  if (error instanceof Error) {
+    throw new AuthServiceError(error.message)
+  }
+
+  throw new AuthServiceError('Une erreur inattendue est survenue.')
+}
+
+export const AuthService = {
+  async getSession() {
+    try {
+      const { data } = await axios.get(`${API}/api/admin/me`)
+      return data as AdminSession
+    } catch (error) {
+      return normalizeError(error)
+    }
+  },
+
+  async getPermissions() {
+    try {
+      const { data } = await axios.get(`${API}/api/admin/permissions`)
+      return data as AdminPermissionsResponse
+    } catch (error) {
+      return normalizeError(error)
+    }
+  }
+}

--- a/src/utils/adminNavigation.ts
+++ b/src/utils/adminNavigation.ts
@@ -1,0 +1,39 @@
+export interface AdminModuleConfig {
+  path: string
+  label: string
+  requiredPermissions: string[]
+  description?: string
+}
+
+export const ADMIN_MODULES: AdminModuleConfig[] = [
+  {
+    path: 'users',
+    label: 'Utilisateurs',
+    requiredPermissions: ['users:read'],
+    description: 'Gérez les comptes utilisateurs et leurs statuts.'
+  },
+  {
+    path: 'events',
+    label: 'Événements',
+    requiredPermissions: ['events:read'],
+    description: 'Supervisez les événements publiés sur Meetinity.'
+  },
+  {
+    path: 'moderation',
+    label: 'Modération',
+    requiredPermissions: ['moderation:read'],
+    description: 'Suivez les signalements et prenez des mesures disciplinaires.'
+  },
+  {
+    path: 'reports',
+    label: 'Rapports',
+    requiredPermissions: ['reports:read'],
+    description: 'Analysez les indicateurs clés de la plateforme.'
+  },
+  {
+    path: 'settings',
+    label: 'Paramètres',
+    requiredPermissions: ['settings:read'],
+    description: 'Configurez les paramètres globaux et les intégrations.'
+  }
+]


### PR DESCRIPTION
## Summary
- create an authentication service and context to centralise session and permission loading
- add an admin layout with sidebar navigation and breadcrumbs for future modules
- protect admin routes with a permission-aware guard and cover behaviour with routing tests

## Testing
- `npm test -- --runInBand` *(fails: `sh: 1: vitest: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_68d999d38f8c8332891b28ae21689f44