### PR TITLE
feat: add event management admin module

### DIFF
--- a/src/__tests__/eventManagement.test.tsx
+++ b/src/__tests__/eventManagement.test.tsx
@@ -1,0 +1,291 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+vi.mock('../services/eventService', () => ({
+  EventService: {
+    list: vi.fn(),
+    listCategories: vi.fn(),
+    listTags: vi.fn(),
+    bulk: vi.fn(),
+    bulkTags: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    createCategory: vi.fn(),
+    updateCategory: vi.fn(),
+    deleteCategory: vi.fn()
+  }
+}))
+
+expect.extend(matchers)
+
+import { EventManagement } from '../components/events/EventManagement'
+import { EventActionsBar } from '../components/events/EventActionsBar'
+import { EventFilters, type EventFiltersState } from '../components/events/EventFilters'
+import { EventTable } from '../components/events/EventTable'
+import type { Event } from '../services/eventService'
+import { EventService } from '../services/eventService'
+
+const baseEvent: Event = {
+  id: 'event-1',
+  title: 'Salon Tech',
+  status: 'pending',
+  categoryId: 'cat-1',
+  category: { id: 'cat-1', name: 'Tech' },
+  startDate: '2024-06-01T10:00',
+  endDate: '2024-06-01T12:00',
+  organizer: 'Meetinity',
+  location: 'Paris',
+  tags: ['innovation']
+}
+
+describe('events module', () => {
+  beforeEach(() => {
+    ;(EventService.list as Mock).mockResolvedValue({ events: [baseEvent], total: 1 })
+    ;(EventService.listCategories as Mock).mockResolvedValue([{ id: 'cat-1', name: 'Tech' }])
+    ;(EventService.listTags as Mock).mockResolvedValue(['innovation'])
+    ;(EventService.bulk as Mock).mockResolvedValue(undefined)
+    ;(EventService.bulkTags as Mock).mockResolvedValue(undefined)
+    ;(EventService.create as Mock).mockResolvedValue(baseEvent)
+    ;(EventService.update as Mock).mockResolvedValue(baseEvent)
+    ;(EventService.createCategory as Mock).mockResolvedValue({ id: 'cat-2', name: 'Marketing' })
+    ;(EventService.updateCategory as Mock).mockResolvedValue({ id: 'cat-1', name: 'Tech+' })
+    ;(EventService.deleteCategory as Mock).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('updates filters and corrects pagination automatically', async () => {
+    const responses = [
+      {
+        expectedPage: 0,
+        expectedStatus: '',
+        result: {
+          events: [baseEvent],
+          total: 80
+        }
+      },
+      {
+        expectedPage: 1,
+        expectedStatus: '',
+        result: {
+          events: [
+            {
+              ...baseEvent,
+              id: 'event-2',
+              title: 'Conférence produit'
+            }
+          ],
+          total: 80
+        }
+      },
+      {
+        expectedPage: 0,
+        expectedStatus: 'pending',
+        result: {
+          events: [
+            {
+              ...baseEvent,
+              id: 'event-3',
+              title: 'Demande en cours'
+            }
+          ],
+          total: 10
+        }
+      }
+    ]
+
+    let callIndex = 0
+    ;(EventService.list as Mock).mockImplementation(async params => {
+      const response = responses[Math.min(callIndex, responses.length - 1)]
+      expect(params.page).toBe(response.expectedPage)
+      expect(params.status).toBe(response.expectedStatus)
+      callIndex += 1
+      return response.result
+    })
+
+    render(<EventManagement />, { legacyRoot: true })
+
+    await waitFor(() => expect(screen.getByText('Salon Tech')).toBeInTheDocument())
+
+    const nextButton = screen.getByRole('button', { name: 'Suivant' })
+    fireEvent.click(nextButton)
+
+    await waitFor(() => expect(screen.getByText('Conférence produit')).toBeInTheDocument())
+
+    const statusSelect = screen.getByLabelText('Statut')
+    fireEvent.change(statusSelect, { target: { value: 'pending' } })
+
+    await waitFor(() => expect(screen.getByText('Demande en cours')).toBeInTheDocument())
+    expect(screen.getByText('Page 1 / 1')).toBeInTheDocument()
+  })
+
+  it('performs bulk actions and recalculates the current page', async () => {
+    const responses = [
+      { expectedPage: 0, events: [{ ...baseEvent, id: 'e-1', title: 'Jour 1' }], total: 60 },
+      { expectedPage: 1, events: [{ ...baseEvent, id: 'e-2', title: 'Jour 2' }], total: 60 },
+      { expectedPage: 2, events: [{ ...baseEvent, id: 'e-3', title: 'Jour 3' }], total: 60 },
+      { expectedPage: 2, events: [], total: 20 },
+      { expectedPage: 0, events: [{ ...baseEvent, id: 'e-1', title: 'Jour 1' }], total: 20 }
+    ]
+
+    let index = 0
+    ;(EventService.list as Mock).mockImplementation(async params => {
+      const response = responses[Math.min(index, responses.length - 1)]
+      expect(params.page).toBe(response.expectedPage)
+      index += 1
+      return { events: response.events, total: response.total }
+    })
+
+    render(<EventManagement />, { legacyRoot: true })
+
+    await waitFor(() => expect(screen.getByText('Jour 1')).toBeInTheDocument())
+
+    const nextButton = screen.getByRole('button', { name: 'Suivant' })
+    fireEvent.click(nextButton)
+    await waitFor(() => expect(screen.getByText('Jour 2')).toBeInTheDocument())
+
+    fireEvent.click(nextButton)
+    await waitFor(() => expect(screen.getByText('Jour 3')).toBeInTheDocument())
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    const rowCheckbox = checkboxes[1] as HTMLInputElement
+    fireEvent.click(rowCheckbox)
+    await waitFor(() => expect(rowCheckbox).toBeChecked())
+
+    const archiveButton = screen.getByRole('button', { name: 'Archiver' })
+    fireEvent.click(archiveButton)
+
+    await waitFor(() => expect(EventService.bulk).toHaveBeenCalledWith(['e-3'], 'archive'))
+    await waitFor(() => expect(screen.getByText('Jour 1')).toBeInTheDocument())
+    expect(screen.getByText('Page 1 / 1')).toBeInTheDocument()
+  })
+
+  it('submits the event form and refreshes the list', async () => {
+    render(<EventManagement />, { legacyRoot: true })
+
+    await waitFor(() => expect(EventService.list).toHaveBeenCalled())
+
+    const createButton = screen.getByRole('button', { name: 'Créer un événement' })
+    fireEvent.click(createButton)
+
+    const titleInput = screen.getByLabelText('Titre') as HTMLInputElement
+    fireEvent.change(titleInput, { target: { value: 'Meetup produit' } })
+
+    const startDateInput = screen.getByLabelText('Date de début') as HTMLInputElement
+    fireEvent.change(startDateInput, { target: { value: '2024-06-02T09:00' } })
+
+    const categorySelect = screen.getByLabelText('Catégorie') as HTMLSelectElement
+    fireEvent.change(categorySelect, { target: { value: 'cat-1' } })
+
+    const tagsInput = screen.getByLabelText('Tags') as HTMLInputElement
+    fireEvent.change(tagsInput, { target: { value: 'nouveau, lancement' } })
+
+    const saveButton = screen.getByRole('button', { name: 'Enregistrer' })
+    fireEvent.click(saveButton)
+
+    await waitFor(() =>
+      expect(EventService.create).toHaveBeenCalledWith({
+        title: 'Meetup produit',
+        description: '',
+        status: 'draft',
+        categoryId: 'cat-1',
+        startDate: '2024-06-02T09:00',
+        endDate: undefined,
+        organizer: undefined,
+        location: undefined,
+        tags: ['nouveau', 'lancement']
+      })
+    )
+
+    await waitFor(() => expect(EventService.list).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText('Enregistrer')).not.toBeInTheDocument()
+  })
+
+  it('applies tags in bulk from the actions bar', async () => {
+    const eventRows: Event[] = [
+      { ...baseEvent, id: 'bulk-1', title: 'Salon 1' },
+      { ...baseEvent, id: 'bulk-2', title: 'Salon 2' }
+    ]
+    ;(EventService.list as Mock).mockResolvedValue({ events: eventRows, total: eventRows.length })
+
+    render(<EventManagement />, { legacyRoot: true })
+
+    await waitFor(() => expect(screen.getByText('Salon 1')).toBeInTheDocument())
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[1])
+    fireEvent.click(checkboxes[2])
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getAllByRole('checkbox')
+          .slice(1, 3)
+          .every(checkbox => (checkbox as HTMLInputElement).checked)
+      ).toBe(true)
+    )
+
+    const tagsField = screen.getByPlaceholderText('tag1, tag2') as HTMLInputElement
+    fireEvent.change(tagsField, { target: { value: 'urgent, priorité' } })
+
+    const applyButton = screen.getByRole('button', { name: 'Appliquer les tags' })
+    fireEvent.click(applyButton)
+
+    await waitFor(() => expect(EventService.bulkTags).toHaveBeenCalledWith(['bulk-1', 'bulk-2'], ['urgent', 'priorité']))
+    await waitFor(() => expect(EventService.list).toHaveBeenCalledTimes(2))
+  })
+
+  it('exposes standalone components behaviour', () => {
+    const filtersState: EventFiltersState = {
+      search: '',
+      status: '',
+      categoryId: '',
+      startDate: '',
+      endDate: ''
+    }
+    const handleFilters = vi.fn()
+
+    render(<EventFilters filters={filtersState} onChange={handleFilters} categories={[]} />)
+    fireEvent.change(screen.getByPlaceholderText('Rechercher un événement'), { target: { value: 'expo' } })
+    expect(handleFilters).toHaveBeenCalledWith({ search: 'expo' })
+
+    const actionsApprove = vi.fn()
+    const actionsTags = vi.fn()
+    render(
+      <EventActionsBar
+        selected={['a']}
+        onApprove={actionsApprove}
+        onReject={() => {}}
+        onArchive={() => {}}
+        onCreate={() => {}}
+        onManageCategories={() => {}}
+        onRefresh={() => {}}
+        onApplyTags={actionsTags}
+        availableTags={['innovation']}
+      />
+    )
+
+    fireEvent.change(screen.getAllByPlaceholderText('tag1, tag2')[0], { target: { value: 'focus' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Appliquer les tags' }))
+    expect(actionsTags).toHaveBeenCalledWith(['focus'])
+
+    render(
+      <EventTable
+        data={[baseEvent]}
+        total={1}
+        page={0}
+        pageSize={20}
+        onPageChange={() => {}}
+        onSelect={() => {}}
+        onEdit={() => {}}
+      />
+    )
+
+    expect(screen.getByText('Salon Tech')).toBeInTheDocument()
+  })
+})

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { UserManagement } from './components/UserManagement'
+import { EventManagement } from './components/events/EventManagement'
 import { AuthProvider, usePermissions } from './hooks/usePermissions'
 import { AdminLayout } from './components/layout/AdminLayout'
 import { ADMIN_MODULES } from './utils/adminNavigation'
@@ -87,6 +88,8 @@ export default function App() {
                   >
                     {module.path === 'users' ? (
                       <UserManagement />
+                    ) : module.path === 'events' ? (
+                      <EventManagement />
                     ) : (
                       <ModulePlaceholder title={module.label} description={module.description} />
                     )}
@@ -94,6 +97,14 @@ export default function App() {
                 }
               />
             ))}
+            <Route
+              path="events/requests"
+              element={
+                <RequirePermissions requiredPermissions={['admin:access', 'events:approve']}>
+                  <EventManagement initialFilters={{ status: 'pending' }} lockedStatus="pending" />
+                </RequirePermissions>
+              }
+            />
           </Route>
           <Route path="/unauthorized" element={<UnauthorizedPage />} />
           <Route path="*" element={<Navigate to="/admin" replace />} />

--- a/src/components/events/EventActionsBar.tsx
+++ b/src/components/events/EventActionsBar.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo, useState } from 'react'
+
+interface EventActionsBarProps {
+  selected: string[]
+  onApprove: () => void
+  onReject: () => void
+  onArchive: () => void
+  onCreate: () => void
+  onManageCategories: () => void
+  onRefresh: () => void
+  onApplyTags: (tags: string[]) => void
+  availableTags: string[]
+}
+
+export function EventActionsBar({
+  selected,
+  onApprove,
+  onReject,
+  onArchive,
+  onCreate,
+  onManageCategories,
+  onRefresh,
+  onApplyTags,
+  availableTags
+}: EventActionsBarProps) {
+  const [tagsInput, setTagsInput] = useState('')
+
+  const isSelectionEmpty = selected.length === 0
+  const parsedTags = useMemo(
+    () =>
+      tagsInput
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(Boolean),
+    [tagsInput]
+  )
+
+  const canApplyTags = parsedTags.length > 0 && !isSelectionEmpty
+
+  const handleApplyTags = () => {
+    if (parsedTags.length === 0) {
+      return
+    }
+    onApplyTags(parsedTags)
+    setTagsInput('')
+  }
+
+  return (
+    <section className="event-actions">
+      <div className="event-actions__primary">
+        <button type="button" onClick={onCreate}>
+          Créer un événement
+        </button>
+        <button type="button" onClick={onManageCategories}>
+          Gérer les catégories
+        </button>
+        <button type="button" onClick={onRefresh}>
+          Rafraîchir
+        </button>
+      </div>
+      <div className="event-actions__bulk">
+        <label className="event-actions__tags-field">
+          <span className="event-actions__label">Tags</span>
+          <input
+            placeholder="tag1, tag2"
+            value={tagsInput}
+            onChange={event => setTagsInput(event.target.value)}
+            list="event-tags-suggestions"
+          />
+          <datalist id="event-tags-suggestions">
+            {availableTags.map(tag => (
+              <option key={tag} value={tag} />
+            ))}
+          </datalist>
+        </label>
+        <button type="button" disabled={!canApplyTags} onClick={handleApplyTags}>
+          Appliquer les tags
+        </button>
+        <button type="button" disabled={isSelectionEmpty} onClick={onApprove}>
+          Approuver
+        </button>
+        <button type="button" disabled={isSelectionEmpty} onClick={onReject}>
+          Rejeter
+        </button>
+        <button type="button" disabled={isSelectionEmpty} onClick={onArchive}>
+          Archiver
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/src/components/events/EventCategoriesManager.tsx
+++ b/src/components/events/EventCategoriesManager.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react'
+import { EventService, type EventCategory } from '../../services/eventService'
+
+interface EventCategoriesManagerProps {
+  categories: EventCategory[]
+  onCategoriesChange: () => Promise<void> | void
+}
+
+export function EventCategoriesManager({ categories, onCategoriesChange }: EventCategoriesManagerProps) {
+  const [name, setName] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState('')
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!name.trim()) {
+      return
+    }
+    setIsSubmitting(true)
+    try {
+      await EventService.createCategory({ name: name.trim() })
+      setName('')
+      await onCategoriesChange()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleStartEdit = (category: EventCategory) => {
+    setEditingId(category.id)
+    setEditingName(category.name)
+  }
+
+  const handleSaveEdit = async (categoryId: string) => {
+    if (!editingName.trim()) {
+      return
+    }
+    setIsSubmitting(true)
+    try {
+      await EventService.updateCategory(categoryId, { name: editingName.trim() })
+      setEditingId(null)
+      setEditingName('')
+      await onCategoriesChange()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (categoryId: string) => {
+    setIsSubmitting(true)
+    try {
+      await EventService.deleteCategory(categoryId)
+      await onCategoriesChange()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="event-categories">
+      <h3>Gestion des catégories</h3>
+      <form className="event-categories__create" onSubmit={handleCreate}>
+        <input
+          placeholder="Nom de la catégorie"
+          value={name}
+          onChange={event => setName(event.target.value)}
+          disabled={isSubmitting}
+        />
+        <button type="submit" disabled={isSubmitting || name.trim().length === 0}>
+          Ajouter
+        </button>
+      </form>
+      <ul className="event-categories__list">
+        {categories.map(category => (
+          <li key={category.id} className="event-categories__item">
+            {editingId === category.id ? (
+              <>
+                <input value={editingName} onChange={event => setEditingName(event.target.value)} />
+                <button type="button" onClick={() => handleSaveEdit(category.id)} disabled={isSubmitting}>
+                  Enregistrer
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingId(null)
+                    setEditingName('')
+                  }}
+                  disabled={isSubmitting}
+                >
+                  Annuler
+                </button>
+              </>
+            ) : (
+              <>
+                <span className="event-categories__name">{category.name}</span>
+                <button type="button" onClick={() => handleStartEdit(category)} disabled={isSubmitting}>
+                  Renommer
+                </button>
+                <button type="button" onClick={() => handleDelete(category.id)} disabled={isSubmitting}>
+                  Supprimer
+                </button>
+              </>
+            )}
+          </li>
+        ))}
+        {categories.length === 0 && <li>Aucune catégorie disponible</li>}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import type { EventCategory } from '../../services/eventService'
+
+export interface EventFiltersState {
+  search: string
+  status: string
+  categoryId: string
+  startDate: string
+  endDate: string
+}
+
+interface EventFiltersProps {
+  filters: EventFiltersState
+  onChange: (filters: Partial<EventFiltersState>) => void
+  categories: EventCategory[]
+  statuses?: Array<{ value: string; label: string }>
+  disableStatus?: boolean
+}
+
+export function EventFilters({ filters, onChange, categories, statuses, disableStatus }: EventFiltersProps) {
+  const statusOptions =
+    statuses ?? (
+      [
+        { value: '', label: 'Tous les statuts' },
+        { value: 'draft', label: 'Brouillons' },
+        { value: 'pending', label: 'En attente' },
+        { value: 'published', label: 'Publiés' },
+        { value: 'rejected', label: 'Rejetés' },
+        { value: 'archived', label: 'Archivés' }
+      ] as Array<{ value: string; label: string }>
+    )
+
+  return (
+    <section className="event-filters">
+      <div className="event-filters__row">
+        <label className="event-filters__field">
+          <span className="event-filters__label">Recherche</span>
+          <input
+            placeholder="Rechercher un événement"
+            value={filters.search}
+            onChange={e => onChange({ search: e.target.value })}
+          />
+        </label>
+        <label className="event-filters__field">
+          <span className="event-filters__label">Statut</span>
+          <select
+            value={filters.status}
+            disabled={disableStatus}
+            onChange={e => onChange({ status: e.target.value })}
+          >
+            {statusOptions.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="event-filters__field">
+          <span className="event-filters__label">Catégorie</span>
+          <select value={filters.categoryId} onChange={e => onChange({ categoryId: e.target.value })}>
+            <option value="">Toutes les catégories</option>
+            {categories.map(category => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="event-filters__row">
+        <label className="event-filters__field">
+          <span className="event-filters__label">Date de début</span>
+          <input
+            type="date"
+            value={filters.startDate}
+            onChange={e => onChange({ startDate: e.target.value })}
+          />
+        </label>
+        <label className="event-filters__field">
+          <span className="event-filters__label">Date de fin</span>
+          <input type="date" value={filters.endDate} onChange={e => onChange({ endDate: e.target.value })} />
+        </label>
+      </div>
+    </section>
+  )
+}

--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import type { Event, EventCategory, EventInput, EventStatus } from '../../services/eventService'
+
+interface EventFormProps {
+  event?: Event | null
+  categories: EventCategory[]
+  availableTags?: string[]
+  onSave: (payload: EventInput) => Promise<void> | void
+  onCancel: () => void
+}
+
+const STATUS_OPTIONS: Array<{ value: EventStatus; label: string }> = [
+  { value: 'draft', label: 'Brouillon' },
+  { value: 'pending', label: 'En attente' },
+  { value: 'published', label: 'Publié' },
+  { value: 'rejected', label: 'Rejeté' },
+  { value: 'archived', label: 'Archivé' }
+]
+
+export function EventForm({ event, categories, availableTags = [], onSave, onCancel }: EventFormProps) {
+  const [title, setTitle] = useState(event?.title ?? '')
+  const [description, setDescription] = useState(event?.description ?? '')
+  const [status, setStatus] = useState<EventStatus>(event?.status ?? 'draft')
+  const [categoryId, setCategoryId] = useState(event?.categoryId ?? '')
+  const [startDate, setStartDate] = useState(event?.startDate ?? '')
+  const [endDate, setEndDate] = useState(event?.endDate ?? '')
+  const [organizer, setOrganizer] = useState(event?.organizer ?? '')
+  const [location, setLocation] = useState(event?.location ?? '')
+  const [tagsInput, setTagsInput] = useState(event?.tags.join(', ') ?? '')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    setTitle(event?.title ?? '')
+    setDescription(event?.description ?? '')
+    setStatus(event?.status ?? 'draft')
+    setCategoryId(event?.categoryId ?? '')
+    setStartDate(event?.startDate ?? '')
+    setEndDate(event?.endDate ?? '')
+    setOrganizer(event?.organizer ?? '')
+    setLocation(event?.location ?? '')
+    setTagsInput(event?.tags.join(', ') ?? '')
+  }, [event])
+
+  const parsedTags = useMemo(
+    () =>
+      tagsInput
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(Boolean),
+    [tagsInput]
+  )
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    try {
+      const payload: EventInput = {
+        title,
+        description,
+        status,
+        categoryId: categoryId || undefined,
+        startDate,
+        endDate: endDate || undefined,
+        organizer: organizer || undefined,
+        location: location || undefined,
+        tags: parsedTags
+      }
+      await onSave(payload)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const isValid = title.trim().length > 0 && startDate.trim().length > 0
+
+  return (
+    <form className="event-form" onSubmit={handleSubmit}>
+      <h2 className="event-form__title">{event ? 'Modifier un événement' : 'Créer un événement'}</h2>
+      <div className="event-form__grid">
+        <label className="event-form__field">
+          <span>Titre</span>
+          <input value={title} onChange={e => setTitle(e.target.value)} required />
+        </label>
+        <label className="event-form__field">
+          <span>Statut</span>
+          <select value={status} onChange={e => setStatus(e.target.value as EventStatus)}>
+            {STATUS_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="event-form__field">
+          <span>Catégorie</span>
+          <select value={categoryId} onChange={e => setCategoryId(e.target.value)}>
+            <option value="">Aucune catégorie</option>
+            {categories.map(category => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="event-form__field">
+          <span>Organisateur</span>
+          <input value={organizer} onChange={e => setOrganizer(e.target.value)} />
+        </label>
+        <label className="event-form__field">
+          <span>Lieu</span>
+          <input value={location} onChange={e => setLocation(e.target.value)} />
+        </label>
+        <label className="event-form__field">
+          <span>Date de début</span>
+          <input type="datetime-local" value={startDate} onChange={e => setStartDate(e.target.value)} required />
+        </label>
+        <label className="event-form__field">
+          <span>Date de fin</span>
+          <input type="datetime-local" value={endDate} onChange={e => setEndDate(e.target.value)} />
+        </label>
+        <label className="event-form__field event-form__field--wide">
+          <span>Description</span>
+          <textarea value={description} onChange={e => setDescription(e.target.value)} rows={4} />
+        </label>
+        <label className="event-form__field event-form__field--wide">
+          <span>Tags</span>
+          <input
+            value={tagsInput}
+            onChange={e => setTagsInput(e.target.value)}
+            placeholder="tag1, tag2"
+            list="event-form-tags"
+          />
+          <datalist id="event-form-tags">
+            {availableTags.map(tag => (
+              <option key={tag} value={tag} />
+            ))}
+          </datalist>
+        </label>
+      </div>
+      <div className="event-form__actions">
+        <button type="button" onClick={onCancel}>
+          Annuler
+        </button>
+        <button type="submit" disabled={!isValid || isSubmitting}>
+          {isSubmitting ? 'Enregistrement…' : 'Enregistrer'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/events/EventManagement.tsx
+++ b/src/components/events/EventManagement.tsx
@@ -1,0 +1,249 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Event,
+  EventCategory,
+  EventInput,
+  EventService
+} from '../../services/eventService'
+import { EventFilters, EventFiltersState } from './EventFilters'
+import { EventTable } from './EventTable'
+import { EventActionsBar } from './EventActionsBar'
+import { EventForm } from './EventForm'
+import { EventCategoriesManager } from './EventCategoriesManager'
+import { useDebounce } from '../../hooks/useDebounce'
+import { usePagination } from '../../hooks/usePagination'
+
+interface EventManagementProps {
+  initialFilters?: Partial<EventFiltersState>
+  lockedStatus?: string
+}
+
+export function EventManagement({ initialFilters, lockedStatus }: EventManagementProps) {
+  const initialState = useMemo<EventFiltersState>(
+    () => ({
+      search: initialFilters?.search ?? '',
+      status: lockedStatus ?? initialFilters?.status ?? '',
+      categoryId: initialFilters?.categoryId ?? '',
+      startDate: initialFilters?.startDate ?? '',
+      endDate: initialFilters?.endDate ?? ''
+    }),
+    [initialFilters, lockedStatus]
+  )
+
+  const [events, setEvents] = useState<Event[]>([])
+  const [total, setTotal] = useState(0)
+  const [filters, setFilters] = useState<EventFiltersState>(initialState)
+  const [categories, setCategories] = useState<EventCategory[]>([])
+  const [availableTags, setAvailableTags] = useState<string[]>([])
+  const [selected, setSelected] = useState<string[]>([])
+  const [selectionResetKey, setSelectionResetKey] = useState(0)
+  const [editingEvent, setEditingEvent] = useState<Event | null>(null)
+  const [isFormOpen, setIsFormOpen] = useState(false)
+  const [isCategoriesOpen, setIsCategoriesOpen] = useState(false)
+
+  const debouncedSearch = useDebounce(filters.search)
+  const { page, pageSize, setPage } = usePagination(20)
+
+  const requestIdRef = useRef(0)
+
+  useEffect(() => {
+    if (lockedStatus && filters.status !== lockedStatus) {
+      setFilters(prev => ({ ...prev, status: lockedStatus }))
+    }
+  }, [filters.status, lockedStatus])
+
+  const loadEvents = useCallback(async () => {
+    const requestId = requestIdRef.current + 1
+    requestIdRef.current = requestId
+
+    const res = await EventService.list({
+      page,
+      pageSize,
+      search: debouncedSearch,
+      status: lockedStatus ?? filters.status,
+      categoryId: filters.categoryId,
+      startDate: filters.startDate,
+      endDate: filters.endDate
+    })
+
+    if (requestId !== requestIdRef.current) {
+      return null
+    }
+
+    setEvents(res.events)
+    setTotal(res.total)
+    return res
+  }, [
+    page,
+    pageSize,
+    debouncedSearch,
+    filters.status,
+    filters.categoryId,
+    filters.startDate,
+    filters.endDate,
+    lockedStatus
+  ])
+
+  const ensurePageWithinBounds = useCallback(
+    (count: number) => {
+      const maxPage = Math.max(0, Math.ceil(count / pageSize) - 1)
+      if (page > maxPage) {
+        setPage(maxPage)
+      }
+    },
+    [page, pageSize, setPage]
+  )
+
+  const loadCategories = useCallback(async () => {
+    const data = await EventService.listCategories()
+    setCategories(data)
+  }, [])
+
+  const loadTags = useCallback(async () => {
+    try {
+      const data = await EventService.listTags()
+      setAvailableTags(data)
+    } catch (error) {
+      console.error('Failed to load event tags', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadCategories()
+    loadTags()
+  }, [loadCategories, loadTags])
+
+  useEffect(() => {
+    const refresh = async () => {
+      const res = await loadEvents()
+      if (res) {
+        ensurePageWithinBounds(res.total)
+      }
+    }
+
+    refresh()
+  }, [loadEvents, ensurePageWithinBounds])
+
+  const handleFilterChange = (partial: Partial<EventFiltersState>) => {
+    setFilters(prev => {
+      const next = { ...prev, ...partial }
+      if (lockedStatus) {
+        next.status = lockedStatus
+      }
+      return next
+    })
+    setPage(0)
+  }
+
+  const handleBulkAction = async (action: 'approve' | 'reject' | 'archive') => {
+    if (selected.length === 0) {
+      return
+    }
+    await EventService.bulk(selected, action)
+    setSelected([])
+    setSelectionResetKey(prev => prev + 1)
+    const res = await loadEvents()
+    if (res) {
+      ensurePageWithinBounds(res.total)
+    }
+  }
+
+  const handleApplyTags = async (tags: string[]) => {
+    if (selected.length === 0 || tags.length === 0) {
+      return
+    }
+    await EventService.bulkTags(selected, tags)
+    setSelected([])
+    setSelectionResetKey(prev => prev + 1)
+    const res = await loadEvents()
+    if (res) {
+      ensurePageWithinBounds(res.total)
+    }
+    await loadTags()
+  }
+
+  const handleCreate = () => {
+    setEditingEvent(null)
+    setIsFormOpen(true)
+  }
+
+  const handleEdit = (event: Event) => {
+    setEditingEvent(event)
+    setIsFormOpen(true)
+  }
+
+  const handleSave = async (payload: EventInput) => {
+    if (editingEvent) {
+      await EventService.update(editingEvent.id, payload)
+    } else {
+      await EventService.create(payload)
+    }
+    setIsFormOpen(false)
+    setEditingEvent(null)
+    const res = await loadEvents()
+    if (res) {
+      ensurePageWithinBounds(res.total)
+    }
+    await loadTags()
+  }
+
+  const handleCancelForm = () => {
+    setIsFormOpen(false)
+    setEditingEvent(null)
+  }
+
+  const handleToggleCategories = () => {
+    setIsCategoriesOpen(open => !open)
+  }
+
+  const handleRefresh = async () => {
+    const res = await loadEvents()
+    if (res) {
+      ensurePageWithinBounds(res.total)
+    }
+  }
+
+  return (
+    <div className="event-management">
+      <EventFilters
+        filters={filters}
+        onChange={handleFilterChange}
+        categories={categories}
+        disableStatus={Boolean(lockedStatus)}
+      />
+      <EventActionsBar
+        selected={selected}
+        onApprove={() => handleBulkAction('approve')}
+        onReject={() => handleBulkAction('reject')}
+        onArchive={() => handleBulkAction('archive')}
+        onCreate={handleCreate}
+        onManageCategories={handleToggleCategories}
+        onRefresh={handleRefresh}
+        onApplyTags={handleApplyTags}
+        availableTags={availableTags}
+      />
+      {isFormOpen && (
+        <EventForm
+          event={editingEvent}
+          categories={categories}
+          availableTags={availableTags}
+          onSave={handleSave}
+          onCancel={handleCancelForm}
+        />
+      )}
+      {isCategoriesOpen && (
+        <EventCategoriesManager categories={categories} onCategoriesChange={loadCategories} />
+      )}
+      <EventTable
+        data={events}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={setPage}
+        onSelect={setSelected}
+        onEdit={handleEdit}
+        clearSelectionKey={selectionResetKey}
+      />
+    </div>
+  )
+}

--- a/src/components/events/EventTable.tsx
+++ b/src/components/events/EventTable.tsx
@@ -1,0 +1,162 @@
+import React from 'react'
+import {
+  useReactTable,
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel
+} from '@tanstack/react-table'
+import type { Event } from '../../services/eventService'
+
+interface EventTableProps {
+  data: Event[]
+  total: number
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onSelect: (ids: string[]) => void
+  onEdit: (event: Event) => void
+  clearSelectionKey?: number
+}
+
+export function EventTable({
+  data,
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  onSelect,
+  onEdit,
+  clearSelectionKey
+}: EventTableProps) {
+  const [rowSelection, setRowSelection] = React.useState({})
+
+  const columns = React.useMemo<ColumnDef<Event>[]>(
+    () => [
+      {
+        id: 'select',
+        header: ({ table }) => (
+          <input
+            type="checkbox"
+            checked={table.getIsAllPageRowsSelected()}
+            onChange={table.getToggleAllPageRowsSelectedHandler()}
+          />
+        ),
+        cell: ({ row }) => (
+          <input
+            type="checkbox"
+            checked={row.getIsSelected()}
+            disabled={!row.getCanSelect()}
+            onChange={row.getToggleSelectedHandler()}
+          />
+        )
+      },
+      {
+        accessorKey: 'title',
+        header: 'Titre'
+      },
+      {
+        accessorKey: 'status',
+        header: 'Statut'
+      },
+      {
+        id: 'category',
+        header: 'Catégorie',
+        cell: ({ row }) => row.original.category?.name ?? '—'
+      },
+      {
+        accessorKey: 'startDate',
+        header: 'Début'
+      },
+      {
+        accessorKey: 'endDate',
+        header: 'Fin'
+      },
+      {
+        id: 'tags',
+        header: 'Tags',
+        cell: ({ row }) => (row.original.tags.length ? row.original.tags.join(', ') : '—')
+      },
+      {
+        id: 'actions',
+        header: 'Actions',
+        cell: ({ row }) => (
+          <button type="button" onClick={() => onEdit(row.original)}>
+            Modifier
+          </button>
+        )
+      }
+    ],
+    [onEdit]
+  )
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { rowSelection },
+    enableRowSelection: true,
+    getRowId: row => row.id,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel()
+  })
+
+  React.useEffect(() => {
+    if (clearSelectionKey !== undefined) {
+      setRowSelection({})
+    }
+  }, [clearSelectionKey])
+
+  React.useEffect(() => {
+    onSelect(table.getSelectedRowModel().rows.map(row => row.original.id))
+  }, [rowSelection, onSelect, table])
+
+  const safePageSize = pageSize > 0 ? pageSize : 1
+  const pageCount = Math.max(1, Math.ceil(total / safePageSize))
+  const hasPages = total > 0
+  const canGoPrev = hasPages && page > 0
+  const canGoNext = hasPages && page + 1 < pageCount
+
+  return (
+    <section className="event-table">
+      <table>
+        <thead>
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map(header => (
+                <th key={header.id} onClick={header.column.getToggleSortingHandler() as any}>
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map(row => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+              ))}
+            </tr>
+          ))}
+          {table.getRowModel().rows.length === 0 && (
+            <tr>
+              <td colSpan={columns.length} style={{ textAlign: 'center', padding: '12px' }}>
+                Aucun événement trouvé
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <div className="pagination">
+        <button type="button" disabled={!canGoPrev} onClick={() => canGoPrev && onPageChange(page - 1)}>
+          Précédent
+        </button>
+        <span>{hasPages ? `Page ${page + 1} / ${pageCount}` : 'Aucune page'}</span>
+        <button type="button" disabled={!canGoNext} onClick={() => canGoNext && onPageChange(page + 1)}>
+          Suivant
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,0 +1,117 @@
+import axios from 'axios'
+
+export type EventStatus = 'draft' | 'pending' | 'published' | 'rejected' | 'archived'
+
+export interface EventCategory {
+  id: string
+  name: string
+  description?: string
+  color?: string
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface Event {
+  id: string
+  title: string
+  description?: string
+  status: EventStatus
+  categoryId?: string
+  category?: EventCategory
+  startDate: string
+  endDate?: string
+  organizer?: string
+  location?: string
+  tags: string[]
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface EventListParams {
+  page?: number
+  pageSize?: number
+  search?: string
+  status?: string
+  categoryId?: string
+  startDate?: string
+  endDate?: string
+}
+
+export interface EventInput {
+  title: string
+  description?: string
+  status?: EventStatus
+  categoryId?: string
+  startDate: string
+  endDate?: string
+  organizer?: string
+  location?: string
+  tags?: string[]
+}
+
+export interface EventCategoryInput {
+  name: string
+  description?: string
+  color?: string
+}
+
+const API = import.meta.env.VITE_API_BASE_URL
+
+export const EventService = {
+  async list(params: EventListParams) {
+    const { data } = await axios.get(`${API}/api/events`, { params })
+    return data as { events: Event[]; total: number }
+  },
+  async get(id: string) {
+    const { data } = await axios.get(`${API}/api/events/${id}`)
+    return data as Event
+  },
+  async create(payload: EventInput) {
+    const { data } = await axios.post(`${API}/api/events`, payload)
+    return data as Event
+  },
+  async update(id: string, payload: EventInput) {
+    const { data } = await axios.put(`${API}/api/events/${id}`, payload)
+    return data as Event
+  },
+  async remove(id: string) {
+    await axios.delete(`${API}/api/events/${id}`)
+  },
+  async approve(id: string, notes?: string) {
+    await axios.post(`${API}/api/events/${id}/approve`, { notes })
+  },
+  async reject(id: string, reason?: string) {
+    await axios.post(`${API}/api/events/${id}/reject`, { reason })
+  },
+  async archive(id: string) {
+    await axios.post(`${API}/api/events/${id}/archive`)
+  },
+  async bulk(ids: string[], action: 'approve' | 'reject' | 'archive') {
+    await axios.post(`${API}/api/events/bulk`, { ids, action })
+  },
+  async bulkTags(ids: string[], tags: string[]) {
+    await axios.post(`${API}/api/events/bulk-tags`, { ids, tags })
+  },
+  async updateTags(id: string, tags: string[]) {
+    await axios.put(`${API}/api/events/${id}/tags`, { tags })
+  },
+  async listTags() {
+    const { data } = await axios.get(`${API}/api/events/tags`)
+    return data as string[]
+  },
+  async listCategories() {
+    const { data } = await axios.get(`${API}/api/events/categories`)
+    return data as EventCategory[]
+  },
+  async createCategory(payload: EventCategoryInput) {
+    const { data } = await axios.post(`${API}/api/events/categories`, payload)
+    return data as EventCategory
+  },
+  async updateCategory(id: string, payload: EventCategoryInput) {
+    const { data } = await axios.put(`${API}/api/events/categories/${id}`, payload)
+    return data as EventCategory
+  },
+  async deleteCategory(id: string) {
+    await axios.delete(`${API}/api/events/categories/${id}`)
+  }
+}


### PR DESCRIPTION
## Summary
- introduce an event service that exposes CRUD operations, approval workflow helpers, bulk actions, and tag/category utilities
- implement the event management UI with filters, tables, bulk actions, forms, and a categories manager reusing existing hooks
- register the admin event routes (including requests view) and add unit tests covering loading, filters, form flows, and bulk actions

## Testing
- node ./node_modules/vitest/vitest.mjs eventManagement *(fails: missing optional rollup binary in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d99e9adfe8833291b4148f83ac07b6