### PR TITLE
Add real-time event analytics dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-table": "^8.21.3",
         "axios": "^1.11.0",
         "chart.js": "^4.5.0",
+        "d3": "^7.9.0",
         "date-fns": "^4.1.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
@@ -2246,6 +2247,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2312,6 +2322,407 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -2446,6 +2857,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -3409,7 +3829,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3497,6 +3916,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arguments": {
@@ -4765,6 +5193,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
@@ -4836,6 +5270,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -4858,7 +5298,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-table": "^8.21.3",
     "axios": "^1.11.0",
     "chart.js": "^4.5.0",
+    "d3": "^7.9.0",
     "date-fns": "^4.1.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.3.0",

--- a/src/__tests__/__snapshots__/eventAnalytics.test.tsx.snap
+++ b/src/__tests__/__snapshots__/eventAnalytics.test.tsx.snap
@@ -1,0 +1,87 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Event analytics pipeline > captures reducer transformations snapshot 1`] = `
+{
+  "attendance": [
+    {
+      "eventId": "a",
+      "eventName": "Forum Product",
+      "series": [
+        {
+          "attendance": 110,
+          "date": "2024-01-01",
+          "registrations": 120,
+        },
+        {
+          "attendance": 135,
+          "date": "2024-01-02",
+          "registrations": 140,
+        },
+        {
+          "attendance": 149,
+          "date": "2024-01-03",
+          "registrations": 155,
+        },
+      ],
+    },
+  ],
+  "conversions": [
+    {
+      "stage": "Visiteurs",
+      "value": 420,
+    },
+    {
+      "stage": "Inscrits",
+      "value": 190,
+    },
+    {
+      "stage": "Présents",
+      "value": 150,
+    },
+  ],
+  "funnel": [
+    {
+      "count": 40,
+      "stage": "Soumis",
+    },
+    {
+      "count": 28,
+      "stage": "Vérification",
+    },
+    {
+      "count": 24,
+      "stage": "Approuvés",
+    },
+  ],
+  "heatmap": [
+    {
+      "day": "Lundi",
+      "hour": 9,
+      "value": 30,
+    },
+    {
+      "day": "Lundi",
+      "hour": 10,
+      "value": 50,
+    },
+    {
+      "day": "Mardi",
+      "hour": 14,
+      "value": 70,
+    },
+    {
+      "day": "Mercredi",
+      "hour": 16,
+      "value": 90,
+    },
+  ],
+  "summary": {
+    "averageAttendanceRate": 0.72,
+    "conversionRate": 0.58,
+    "pendingApproval": 4,
+    "published": 30,
+    "rejected": 6,
+    "totalEvents": 45,
+  },
+}
+`;

--- a/src/__tests__/authRouting.test.tsx
+++ b/src/__tests__/authRouting.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import App from '../app'
+import { AuthService } from '../services/authService'
+
+vi.mock('../services/authService', () => ({
+  AuthService: {
+    getSession: vi.fn(),
+    getPermissions: vi.fn()
+  }
+}))
+
+const mockedAuthService = vi.mocked(AuthService, true)
+
+describe('Auth routing guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.pushState({}, '', '/')
+  })
+
+  it('affiche un état de chargement pendant la récupération des permissions', () => {
+    mockedAuthService.getSession.mockReturnValue(new Promise(() => {}))
+    mockedAuthService.getPermissions.mockReturnValue(new Promise(() => {}))
+
+    const { unmount } = render(<App />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Chargement des permissions...')
+
+    unmount()
+  })
+
+  it('autorise l’accès lorsque les permissions requises sont présentes', async () => {
+    window.history.pushState({}, '', '/admin/users')
+
+    mockedAuthService.getSession.mockResolvedValue({
+      id: '1',
+      email: 'admin@example.com',
+      name: 'Admin Example',
+      role: 'super-admin'
+    })
+
+    mockedAuthService.getPermissions.mockResolvedValue({
+      permissions: ['admin:access', 'users:read'],
+      roles: ['super-admin']
+    })
+
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByText('Export CSV')).toBeInTheDocument())
+  })
+
+  it('redirige vers /unauthorized lorsque les permissions sont insuffisantes', async () => {
+    window.history.pushState({}, '', '/admin/events')
+
+    mockedAuthService.getSession.mockResolvedValue({
+      id: '1',
+      email: 'admin@example.com',
+      name: 'Admin Example',
+      role: 'super-admin'
+    })
+
+    mockedAuthService.getPermissions.mockResolvedValue({
+      permissions: ['admin:access', 'users:read'],
+      roles: ['super-admin']
+    })
+
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByText('Accès refusé')).toBeInTheDocument())
+    expect(window.location.pathname).toBe('/unauthorized')
+  })
+})

--- a/src/__tests__/eventAnalytics.test.tsx
+++ b/src/__tests__/eventAnalytics.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { EventManagement, analyticsReducer, EventAnalyticsState } from '../components/events/EventManagement'
+import type {
+  EventApprovalStage,
+  EventAttendanceSeries,
+  EventConversionStat,
+  EventEngagementCell,
+  EventAnalyticsSummary
+} from '../services/eventService'
+
+const subscribers = new Set<(event: MessageEvent) => void>()
+let emitWebSocketMessage: (payload: unknown) => void
+let hasActiveSubscribers = false
+
+emitWebSocketMessage = payload => {
+  const message = typeof payload === 'string' ? payload : JSON.stringify(payload)
+  subscribers.forEach(handler =>
+    handler({
+      data: message
+    } as MessageEvent)
+  )
+}
+
+var fixtures: {
+  summary: EventAnalyticsSummary
+  attendance: EventAttendanceSeries[]
+  conversions: EventConversionStat[]
+  funnel: EventApprovalStage[]
+  heatmap: EventEngagementCell[]
+}
+
+vi.mock('../services/eventService', () => {
+  fixtures = {
+    summary: {
+      totalEvents: 42,
+      published: 30,
+      pendingApproval: 6,
+      rejected: 6,
+      averageAttendanceRate: 0.72,
+      conversionRate: 0.58
+    },
+    attendance: [
+      {
+        eventId: 'a',
+        eventName: 'Forum Product',
+        series: [
+          { date: '2024-01-01', registrations: 120, attendance: 110 },
+          { date: '2024-01-02', registrations: 140, attendance: 135 }
+        ]
+      }
+    ],
+    conversions: [
+      { stage: 'Visiteurs', value: 420 },
+      { stage: 'Inscrits', value: 190 },
+      { stage: 'Présents', value: 140 }
+    ],
+    funnel: [
+      { stage: 'Soumis', count: 40 },
+      { stage: 'Vérification', count: 28 },
+      { stage: 'Approuvés', count: 22 }
+    ],
+    heatmap: [
+      { day: 'Lundi', hour: 9, value: 30 },
+      { day: 'Lundi', hour: 10, value: 50 },
+      { day: 'Mardi', hour: 14, value: 70 }
+    ]
+  }
+
+  return {
+    EventService: {
+      list: vi.fn().mockResolvedValue({ events: [], total: 0 }),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      approve: vi.fn(),
+      reject: vi.fn(),
+      archive: vi.fn(),
+      bulk: vi.fn(),
+      bulkTags: vi.fn(),
+      updateTags: vi.fn(),
+      listTags: vi.fn().mockResolvedValue([]),
+      listCategories: vi.fn().mockResolvedValue([]),
+      createCategory: vi.fn(),
+      updateCategory: vi.fn(),
+      deleteCategory: vi.fn(),
+      getAnalyticsSummary: vi.fn().mockResolvedValue(fixtures.summary),
+      getAttendanceAnalytics: vi.fn().mockResolvedValue(fixtures.attendance),
+      getConversionAnalytics: vi.fn().mockResolvedValue(fixtures.conversions),
+      getApprovalFunnel: vi.fn().mockResolvedValue(fixtures.funnel),
+      getEngagementHeatmap: vi.fn().mockResolvedValue(fixtures.heatmap)
+    }
+  }
+})
+
+vi.mock('../hooks/useWebSocket', () => {
+  return {
+    useWebSocket: () => ({
+      readyState: 1,
+      connectionAttempts: 0,
+      subscribe: (handler: (event: MessageEvent) => void) => {
+        subscribers.add(handler)
+        hasActiveSubscribers = subscribers.size > 0
+        return () => {
+          subscribers.delete(handler)
+          hasActiveSubscribers = subscribers.size > 0
+        }
+      },
+      send: vi.fn(),
+      close: vi.fn()
+    })
+  }
+})
+
+describe('Event analytics pipeline', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:4000')
+    vi.stubEnv('VITE_WS_BASE_URL', 'ws://localhost:5000/ws')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    subscribers.clear()
+    hasActiveSubscribers = false
+    vi.unstubAllEnvs()
+  })
+
+  it('merges realtime WebSocket updates into analytics visuals', async () => {
+    render(<EventManagement />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('analytics-total-events').textContent).toContain('42')
+    )
+
+    await waitFor(() => expect(hasActiveSubscribers).toBe(true))
+
+    await act(async () => {
+      emitWebSocketMessage({ type: 'summary', data: { totalEvents: 43 } })
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('analytics-total-events').textContent).toContain('43')
+    )
+
+    await act(async () => {
+      emitWebSocketMessage({ type: 'conversion', stage: 'Visiteurs', value: 520 })
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('analytics-conversion-Visiteurs').textContent).toContain('520')
+    )
+  })
+
+  it('captures reducer transformations snapshot', () => {
+    const baseState: EventAnalyticsState = {
+      summary: { ...fixtures.summary },
+      attendance: [...fixtures.attendance],
+      conversions: [...fixtures.conversions],
+      funnel: [...fixtures.funnel],
+      heatmap: [...fixtures.heatmap],
+      updatedAt: '2024-01-01T00:00:00.000Z'
+    }
+
+    const actions: Parameters<typeof analyticsReducer>[1][] = [
+      { type: 'PATCH_SUMMARY', payload: { totalEvents: 45, pendingApproval: 4 } },
+      {
+        type: 'UPSERT_ATTENDANCE_POINT',
+        payload: {
+          eventId: 'a',
+          eventName: 'Forum Product',
+          date: '2024-01-03',
+          registrations: 155,
+          attendance: 149
+        }
+      },
+      { type: 'UPSERT_CONVERSION', payload: { stage: 'Présents', value: 150 } },
+      { type: 'UPSERT_FUNNEL_STAGE', payload: { stage: 'Approuvés', count: 24 } },
+      { type: 'UPSERT_HEATMAP_CELL', payload: { day: 'Mercredi', hour: 16, value: 90 } }
+    ]
+
+    const finalState = actions.reduce(analyticsReducer, baseState)
+    const { updatedAt, ...stateWithoutTimestamp } = finalState
+
+    expect(updatedAt).toEqual(expect.any(String))
+    expect(stateWithoutTimestamp).toMatchSnapshot()
+  })
+})
+

--- a/src/__tests__/eventManagement.test.tsx
+++ b/src/__tests__/eventManagement.test.tsx
@@ -1,0 +1,291 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+vi.mock('../services/eventService', () => ({
+  EventService: {
+    list: vi.fn(),
+    listCategories: vi.fn(),
+    listTags: vi.fn(),
+    bulk: vi.fn(),
+    bulkTags: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    createCategory: vi.fn(),
+    updateCategory: vi.fn(),
+    deleteCategory: vi.fn()
+  }
+}))
+
+expect.extend(matchers)
+
+import { EventManagement } from '../components/events/EventManagement'
+import { EventActionsBar } from '../components/events/EventActionsBar'
+import { EventFilters, type EventFiltersState } from '../components/events/EventFilters'
+import { EventTable } from '../components/events/EventTable'
+import type { Event } from '../services/eventService'
+import { EventService } from '../services/eventService'
+
+const baseEvent: Event = {
+  id: 'event-1',
+  title: 'Salon Tech',
+  status: 'pending',
+  categoryId: 'cat-1',
+  category: { id: 'cat-1', name: 'Tech' },
+  startDate: '2024-06-01T10:00',
+  endDate: '2024-06-01T12:00',
+  organizer: 'Meetinity',
+  location: 'Paris',
+  tags: ['innovation']
+}
+
+describe('events module', () => {
+  beforeEach(() => {
+    ;(EventService.list as Mock).mockResolvedValue({ events: [baseEvent], total: 1 })
+    ;(EventService.listCategories as Mock).mockResolvedValue([{ id: 'cat-1', name: 'Tech' }])
+    ;(EventService.listTags as Mock).mockResolvedValue(['innovation'])
+    ;(EventService.bulk as Mock).mockResolvedValue(undefined)
+    ;(EventService.bulkTags as Mock).mockResolvedValue(undefined)
+    ;(EventService.create as Mock).mockResolvedValue(baseEvent)
+    ;(EventService.update as Mock).mockResolvedValue(baseEvent)
+    ;(EventService.createCategory as Mock).mockResolvedValue({ id: 'cat-2', name: 'Marketing' })
+    ;(EventService.updateCategory as Mock).mockResolvedValue({ id: 'cat-1', name: 'Tech+' })
+    ;(EventService.deleteCategory as Mock).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('updates filters and corrects pagination automatically', async () => {
+    const responses = [
+      {
+        expectedPage: 0,
+        expectedStatus: '',
+        result: {
+          events: [baseEvent],
+          total: 80
+        }
+      },
+      {
+        expectedPage: 1,
+        expectedStatus: '',
+        result: {
+          events: [
+            {
+              ...baseEvent,
+              id: 'event-2',
+              title: 'Conférence produit'
+            }
+          ],
+          total: 80
+        }
+      },
+      {
+        expectedPage: 0,
+        expectedStatus: 'pending',
+        result: {
+          events: [
+            {
+              ...baseEvent,
+              id: 'event-3',
+              title: 'Demande en cours'
+            }
+          ],
+          total: 10
+        }
+      }
+    ]
+
+    let callIndex = 0
+    ;(EventService.list as Mock).mockImplementation(async params => {
+      const response = responses[Math.min(callIndex, responses.length - 1)]
+      expect(params.page).toBe(response.expectedPage)
+      expect(params.status).toBe(response.expectedStatus)
+      callIndex += 1
+      return response.result
+    })
+
+    render(<EventManagement />, { legacyRoot: true })
+
+    await waitFor(() => expect(screen.getByText('Salon Tech')).toBeInTheDocument())
+
+    const nextButton = screen.getByRole('button', { name: 'Suivant' })
+    fireEvent.click(nextButton)
+
+    await waitFor(() => expect(screen.getByText('Conférence produit')).toBeInTheDocument())
+
+    const statusSelect = screen.getByLabelText('Statut')
+    fireEvent.change(statusSelect, { target: { value: 'pending' } })
+
+    await waitFor(() => expect(screen.getByText('Demande en cours')).toBeInTheDocument())
+    expect(screen.getByText('Page 1 / 1')).toBeInTheDocument()
+  })
+
+  it('performs bulk actions and recalculates the current page', async () => {
+    const responses = [
+      { expectedPage: 0, events: [{ ...baseEvent, id: 'e-1', title: 'Jour 1' }], total: 60 },
+      { expectedPage: 1, events: [{ ...baseEvent, id: 'e-2', title: 'Jour 2' }], total: 60 },
+      { expectedPage: 2, events: [{ ...baseEvent, id: 'e-3', title: 'Jour 3' }], total: 60 },
+      { expectedPage: 2, events: [], total: 20 },
+      { expectedPage: 0, events: [{ ...baseEvent, id: 'e-1', title: 'Jour 1' }], total: 20 }
+    ]
+
+    let index = 0
+    ;(EventService.list as Mock).mockImplementation(async params => {
+      const response = responses[Math.min(index, responses.length - 1)]
+      expect(params.page).toBe(response.expectedPage)
+      index += 1
+      return { events: response.events, total: response.total }
+    })
+
+    render(<EventManagement />, { legacyRoot: true })
+
+    await waitFor(() => expect(screen.getByText('Jour 1')).toBeInTheDocument())
+
+    const nextButton = screen.getByRole('button', { name: 'Suivant' })
+    fireEvent.click(nextButton)
+    await waitFor(() => expect(screen.getByText('Jour 2')).toBeInTheDocument())
+
+    fireEvent.click(nextButton)
+    await waitFor(() => expect(screen.getByText('Jour 3')).toBeInTheDocument())
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    const rowCheckbox = checkboxes[1] as HTMLInputElement
+    fireEvent.click(rowCheckbox)
+    await waitFor(() => expect(rowCheckbox).toBeChecked())
+
+    const archiveButton = screen.getByRole('button', { name: 'Archiver' })
+    fireEvent.click(archiveButton)
+
+    await waitFor(() => expect(EventService.bulk).toHaveBeenCalledWith(['e-3'], 'archive'))
+    await waitFor(() => expect(screen.getByText('Jour 1')).toBeInTheDocument())
+    expect(screen.getByText('Page 1 / 1')).toBeInTheDocument()
+  })
+
+  it('submits the event form and refreshes the list', async () => {
+    render(<EventManagement />, { legacyRoot: true })
+
+    await waitFor(() => expect(EventService.list).toHaveBeenCalled())
+
+    const createButton = screen.getByRole('button', { name: 'Créer un événement' })
+    fireEvent.click(createButton)
+
+    const titleInput = screen.getByLabelText('Titre') as HTMLInputElement
+    fireEvent.change(titleInput, { target: { value: 'Meetup produit' } })
+
+    const startDateInput = screen.getByLabelText('Date de début') as HTMLInputElement
+    fireEvent.change(startDateInput, { target: { value: '2024-06-02T09:00' } })
+
+    const categorySelect = screen.getByLabelText('Catégorie') as HTMLSelectElement
+    fireEvent.change(categorySelect, { target: { value: 'cat-1' } })
+
+    const tagsInput = screen.getByLabelText('Tags') as HTMLInputElement
+    fireEvent.change(tagsInput, { target: { value: 'nouveau, lancement' } })
+
+    const saveButton = screen.getByRole('button', { name: 'Enregistrer' })
+    fireEvent.click(saveButton)
+
+    await waitFor(() =>
+      expect(EventService.create).toHaveBeenCalledWith({
+        title: 'Meetup produit',
+        description: '',
+        status: 'draft',
+        categoryId: 'cat-1',
+        startDate: '2024-06-02T09:00',
+        endDate: undefined,
+        organizer: undefined,
+        location: undefined,
+        tags: ['nouveau', 'lancement']
+      })
+    )
+
+    await waitFor(() => expect(EventService.list).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText('Enregistrer')).not.toBeInTheDocument()
+  })
+
+  it('applies tags in bulk from the actions bar', async () => {
+    const eventRows: Event[] = [
+      { ...baseEvent, id: 'bulk-1', title: 'Salon 1' },
+      { ...baseEvent, id: 'bulk-2', title: 'Salon 2' }
+    ]
+    ;(EventService.list as Mock).mockResolvedValue({ events: eventRows, total: eventRows.length })
+
+    render(<EventManagement />, { legacyRoot: true })
+
+    await waitFor(() => expect(screen.getByText('Salon 1')).toBeInTheDocument())
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[1])
+    fireEvent.click(checkboxes[2])
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getAllByRole('checkbox')
+          .slice(1, 3)
+          .every(checkbox => (checkbox as HTMLInputElement).checked)
+      ).toBe(true)
+    )
+
+    const tagsField = screen.getByPlaceholderText('tag1, tag2') as HTMLInputElement
+    fireEvent.change(tagsField, { target: { value: 'urgent, priorité' } })
+
+    const applyButton = screen.getByRole('button', { name: 'Appliquer les tags' })
+    fireEvent.click(applyButton)
+
+    await waitFor(() => expect(EventService.bulkTags).toHaveBeenCalledWith(['bulk-1', 'bulk-2'], ['urgent', 'priorité']))
+    await waitFor(() => expect(EventService.list).toHaveBeenCalledTimes(2))
+  })
+
+  it('exposes standalone components behaviour', () => {
+    const filtersState: EventFiltersState = {
+      search: '',
+      status: '',
+      categoryId: '',
+      startDate: '',
+      endDate: ''
+    }
+    const handleFilters = vi.fn()
+
+    render(<EventFilters filters={filtersState} onChange={handleFilters} categories={[]} />)
+    fireEvent.change(screen.getByPlaceholderText('Rechercher un événement'), { target: { value: 'expo' } })
+    expect(handleFilters).toHaveBeenCalledWith({ search: 'expo' })
+
+    const actionsApprove = vi.fn()
+    const actionsTags = vi.fn()
+    render(
+      <EventActionsBar
+        selected={['a']}
+        onApprove={actionsApprove}
+        onReject={() => {}}
+        onArchive={() => {}}
+        onCreate={() => {}}
+        onManageCategories={() => {}}
+        onRefresh={() => {}}
+        onApplyTags={actionsTags}
+        availableTags={['innovation']}
+      />
+    )
+
+    fireEvent.change(screen.getAllByPlaceholderText('tag1, tag2')[0], { target: { value: 'focus' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Appliquer les tags' }))
+    expect(actionsTags).toHaveBeenCalledWith(['focus'])
+
+    render(
+      <EventTable
+        data={[baseEvent]}
+        total={1}
+        page={0}
+        pageSize={20}
+        onPageChange={() => {}}
+        onSelect={() => {}}
+        onEdit={() => {}}
+      />
+    )
+
+    expect(screen.getByText('Salon Tech')).toBeInTheDocument()
+  })
+})

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,26 +1,104 @@
 import React from 'react'
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { UserManagement } from './components/UserManagement'
+import { AuthProvider, usePermissions } from './hooks/usePermissions'
+import { AdminLayout } from './components/layout/AdminLayout'
+import { ADMIN_MODULES } from './utils/adminNavigation'
 
-function AdminRoute({ children }: { children: JSX.Element }) {
-  const isAdmin = localStorage.getItem('role') === 'admin'
-  return isAdmin ? children : <div>Unauthorized</div>
+interface RequirePermissionsProps {
+  requiredPermissions?: string[]
+  children: React.ReactElement
+}
+
+function RequirePermissions({ children, requiredPermissions = [] }: RequirePermissionsProps) {
+  const { isLoading, error, hasPermissions } = usePermissions()
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        style={{ padding: '48px', textAlign: 'center', fontSize: '1rem' }}
+      >
+        Chargement des permissions...
+      </div>
+    )
+  }
+
+  if (error) {
+    return <Navigate to="/unauthorized" replace state={{ message: error }} />
+  }
+
+  if (!hasPermissions(requiredPermissions)) {
+    return <Navigate to="/unauthorized" replace />
+  }
+
+  return children
+}
+
+function UnauthorizedPage() {
+  const location = useLocation<{ message?: string }>()
+  const message = location.state?.message
+
+  return (
+    <section style={{ padding: '64px', textAlign: 'center' }}>
+      <h1 style={{ fontSize: '2rem', marginBottom: '16px' }}>Accès refusé</h1>
+      <p style={{ marginBottom: '16px' }}>
+        {message || "Vous n'avez pas accès à cette section de l'espace d'administration."}
+      </p>
+      <a href="/admin" style={{ color: '#2563eb', textDecoration: 'underline' }}>
+        Retourner au tableau de bord
+      </a>
+    </section>
+  )
+}
+
+function ModulePlaceholder({ title, description }: { title: string; description?: string }) {
+  return (
+    <section>
+      <h2 style={{ fontSize: '1.5rem', marginBottom: '12px' }}>{title}</h2>
+      {description && <p style={{ marginBottom: '12px', color: '#4b5563' }}>{description}</p>}
+      <p style={{ color: '#6b7280' }}>Le module sera disponible prochainement.</p>
+    </section>
+  )
 }
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route
-          path="/admin/users"
-          element={
-            <AdminRoute>
-              <UserManagement />
-            </AdminRoute>
-          }
-        />
-        <Route path="*" element={<Navigate to="/admin/users" replace />} />
-      </Routes>
+      <AuthProvider>
+        <Routes>
+          <Route
+            path="/admin"
+            element={
+              <RequirePermissions requiredPermissions={['admin:access']}>
+                <AdminLayout />
+              </RequirePermissions>
+            }
+          >
+            <Route index element={<Navigate to="users" replace />} />
+            {ADMIN_MODULES.map(module => (
+              <Route
+                key={module.path}
+                path={module.path}
+                element={
+                  <RequirePermissions
+                    requiredPermissions={['admin:access', ...module.requiredPermissions]}
+                  >
+                    {module.path === 'users' ? (
+                      <UserManagement />
+                    ) : (
+                      <ModulePlaceholder title={module.label} description={module.description} />
+                    )}
+                  </RequirePermissions>
+                }
+              />
+            ))}
+          </Route>
+          <Route path="/unauthorized" element={<UnauthorizedPage />} />
+          <Route path="*" element={<Navigate to="/admin" replace />} />
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   )
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { UserManagement } from './components/UserManagement'
+import { EventManagement } from './components/events/EventManagement'
 import { AuthProvider, usePermissions } from './hooks/usePermissions'
 import { AdminLayout } from './components/layout/AdminLayout'
 import { ADMIN_MODULES } from './utils/adminNavigation'
@@ -87,6 +88,8 @@ export default function App() {
                   >
                     {module.path === 'users' ? (
                       <UserManagement />
+                    ) : module.path === 'events' ? (
+                      <EventManagement />
                     ) : (
                       <ModulePlaceholder title={module.label} description={module.description} />
                     )}
@@ -94,6 +97,14 @@ export default function App() {
                 }
               />
             ))}
+            <Route
+              path="events/requests"
+              element={
+                <RequirePermissions requiredPermissions={['admin:access', 'events:approve']}>
+                  <EventManagement initialFilters={{ status: 'pending' }} lockedStatus="pending" />
+                </RequirePermissions>
+              }
+            />
           </Route>
           <Route path="/unauthorized" element={<UnauthorizedPage />} />
           <Route path="*" element={<Navigate to="/admin" replace />} />

--- a/src/components/events/EventActionsBar.tsx
+++ b/src/components/events/EventActionsBar.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo, useState } from 'react'
+
+interface EventActionsBarProps {
+  selected: string[]
+  onApprove: () => void
+  onReject: () => void
+  onArchive: () => void
+  onCreate: () => void
+  onManageCategories: () => void
+  onRefresh: () => void
+  onApplyTags: (tags: string[]) => void
+  availableTags: string[]
+}
+
+export function EventActionsBar({
+  selected,
+  onApprove,
+  onReject,
+  onArchive,
+  onCreate,
+  onManageCategories,
+  onRefresh,
+  onApplyTags,
+  availableTags
+}: EventActionsBarProps) {
+  const [tagsInput, setTagsInput] = useState('')
+
+  const isSelectionEmpty = selected.length === 0
+  const parsedTags = useMemo(
+    () =>
+      tagsInput
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(Boolean),
+    [tagsInput]
+  )
+
+  const canApplyTags = parsedTags.length > 0 && !isSelectionEmpty
+
+  const handleApplyTags = () => {
+    if (parsedTags.length === 0) {
+      return
+    }
+    onApplyTags(parsedTags)
+    setTagsInput('')
+  }
+
+  return (
+    <section className="event-actions">
+      <div className="event-actions__primary">
+        <button type="button" onClick={onCreate}>
+          Créer un événement
+        </button>
+        <button type="button" onClick={onManageCategories}>
+          Gérer les catégories
+        </button>
+        <button type="button" onClick={onRefresh}>
+          Rafraîchir
+        </button>
+      </div>
+      <div className="event-actions__bulk">
+        <label className="event-actions__tags-field">
+          <span className="event-actions__label">Tags</span>
+          <input
+            placeholder="tag1, tag2"
+            value={tagsInput}
+            onChange={event => setTagsInput(event.target.value)}
+            list="event-tags-suggestions"
+          />
+          <datalist id="event-tags-suggestions">
+            {availableTags.map(tag => (
+              <option key={tag} value={tag} />
+            ))}
+          </datalist>
+        </label>
+        <button type="button" disabled={!canApplyTags} onClick={handleApplyTags}>
+          Appliquer les tags
+        </button>
+        <button type="button" disabled={isSelectionEmpty} onClick={onApprove}>
+          Approuver
+        </button>
+        <button type="button" disabled={isSelectionEmpty} onClick={onReject}>
+          Rejeter
+        </button>
+        <button type="button" disabled={isSelectionEmpty} onClick={onArchive}>
+          Archiver
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/src/components/events/EventAnalyticsDashboard.tsx
+++ b/src/components/events/EventAnalyticsDashboard.tsx
@@ -1,0 +1,417 @@
+import React, { useEffect, useMemo, useRef } from 'react'
+import * as d3 from 'd3'
+import {
+  EventAnalyticsSummary,
+  EventAttendanceSeries,
+  EventConversionStat,
+  EventApprovalStage,
+  EventEngagementCell
+} from '../../services/eventService'
+
+export type AnalyticsRangeOption = '7d' | '14d' | '30d' | '90d'
+
+interface EventAnalyticsDashboardProps {
+  summary: EventAnalyticsSummary | null
+  attendance: EventAttendanceSeries[]
+  conversions: EventConversionStat[]
+  funnel: EventApprovalStage[]
+  heatmap: EventEngagementCell[]
+  loading?: boolean
+  lastUpdated?: string
+  connectionState?: number
+  onRangeChange?: (range: AnalyticsRangeOption) => void
+  range?: AnalyticsRangeOption
+}
+
+const rangeLabels: Record<AnalyticsRangeOption, string> = {
+  '7d': '7 derniers jours',
+  '14d': '14 derniers jours',
+  '30d': '30 derniers jours',
+  '90d': '90 derniers jours'
+}
+
+function formatPercent(value: number) {
+  if (Number.isNaN(value)) {
+    return '0%'
+  }
+  return `${Math.round(value * 1000) / 10}%`
+}
+
+function resolveConnectionState(state?: number) {
+  switch (state) {
+    case 0:
+      return { label: 'Connexion en cours', tone: 'pending' }
+    case 1:
+      return { label: 'Temps réel actif', tone: 'online' }
+    case 2:
+      return { label: 'Fermeture de la socket', tone: 'warning' }
+    case 3:
+    default:
+      return { label: 'Hors ligne', tone: 'offline' }
+  }
+}
+
+export function EventAnalyticsDashboard({
+  summary,
+  attendance,
+  conversions,
+  funnel,
+  heatmap,
+  loading,
+  lastUpdated,
+  connectionState,
+  onRangeChange,
+  range = '30d'
+}: EventAnalyticsDashboardProps) {
+  const attendanceRef = useRef<SVGSVGElement | null>(null)
+  const conversionRef = useRef<SVGSVGElement | null>(null)
+  const funnelRef = useRef<SVGSVGElement | null>(null)
+  const heatmapRef = useRef<SVGSVGElement | null>(null)
+
+  const aggregatedAttendance = useMemo(() => {
+    const bucket = new Map<string, { registrations: number; attendance: number }>()
+
+    attendance.forEach(series => {
+      series.series.forEach(point => {
+        if (!bucket.has(point.date)) {
+          bucket.set(point.date, { registrations: 0, attendance: 0 })
+        }
+        const entry = bucket.get(point.date)
+        if (entry) {
+          entry.registrations += point.registrations
+          entry.attendance += point.attendance
+        }
+      })
+    })
+
+    return Array.from(bucket.entries())
+      .map(([date, values]) => ({ date, ...values }))
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+  }, [attendance])
+
+  const topConversion = useMemo(() => {
+    if (!conversions.length) {
+      return null
+    }
+    return conversions.reduce((max, current) => (current.value > max.value ? current : max))
+  }, [conversions])
+
+  const connectionMeta = resolveConnectionState(connectionState)
+
+  useEffect(() => {
+    const svg = d3.select(attendanceRef.current)
+    svg.selectAll('*').remove()
+
+    if (!aggregatedAttendance.length) {
+      return
+    }
+
+    const width = 640
+    const height = 280
+    const margin = { top: 20, right: 20, bottom: 30, left: 48 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+
+    const dates = aggregatedAttendance.map(point => new Date(point.date))
+    const x = d3
+      .scaleTime()
+      .domain(d3.extent(dates) as [Date, Date])
+      .range([margin.left, width - margin.right])
+
+    const y = d3
+      .scaleLinear()
+      .domain([
+        0,
+        d3.max(aggregatedAttendance, point => Math.max(point.registrations, point.attendance)) ?? 1
+      ])
+      .nice()
+      .range([height - margin.bottom, margin.top])
+
+    const lineRegistrations = d3
+      .line<{ date: string; registrations: number; attendance: number }>()
+      .x(point => x(new Date(point.date)))
+      .y(point => y(point.registrations))
+
+    const lineAttendance = d3
+      .line<{ date: string; registrations: number; attendance: number }>()
+      .x(point => x(new Date(point.date)))
+      .y(point => y(point.attendance))
+
+    svg
+      .append('path')
+      .datum(aggregatedAttendance)
+      .attr('fill', 'none')
+      .attr('stroke', '#4f46e5')
+      .attr('stroke-width', 2)
+      .attr('d', lineRegistrations)
+
+    svg
+      .append('path')
+      .datum(aggregatedAttendance)
+      .attr('fill', 'none')
+      .attr('stroke', '#22c55e')
+      .attr('stroke-width', 2)
+      .attr('d', lineAttendance)
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).ticks(5).tickFormat(d3.timeFormat('%d/%m') as (date: Date) => string))
+
+    svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y).ticks(5))
+  }, [aggregatedAttendance])
+
+  useEffect(() => {
+    const svg = d3.select(conversionRef.current)
+    svg.selectAll('*').remove()
+
+    if (!conversions.length) {
+      return
+    }
+
+    const width = 320
+    const height = 240
+    const margin = { top: 20, right: 20, bottom: 40, left: 48 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+
+    const x = d3
+      .scaleBand()
+      .domain(conversions.map(item => item.stage))
+      .range([margin.left, width - margin.right])
+      .padding(0.2)
+
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(conversions, item => item.value) ?? 1])
+      .nice()
+      .range([height - margin.bottom, margin.top])
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x))
+
+    svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y).ticks(5))
+
+    svg
+      .selectAll('rect')
+      .data(conversions)
+      .enter()
+      .append('rect')
+      .attr('x', item => (x(item.stage) ?? 0))
+      .attr('y', item => y(item.value))
+      .attr('width', x.bandwidth())
+      .attr('height', item => y(0) - y(item.value))
+      .attr('fill', '#6366f1')
+  }, [conversions])
+
+  useEffect(() => {
+    const svg = d3.select(funnelRef.current)
+    svg.selectAll('*').remove()
+
+    if (!funnel.length) {
+      return
+    }
+
+    const width = 320
+    const height = 240
+    const margin = { top: 20, right: 20, bottom: 40, left: 48 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+
+    const maxValue = d3.max(funnel, stage => stage.count) ?? 1
+    const y = d3
+      .scaleBand()
+      .domain(funnel.map(stage => stage.stage))
+      .range([margin.top, height - margin.bottom])
+      .padding(0.3)
+
+    const x = d3
+      .scaleLinear()
+      .domain([0, maxValue])
+      .range([margin.left, width - margin.right])
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).ticks(5))
+
+    svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y))
+
+    svg
+      .selectAll('rect')
+      .data(funnel)
+      .enter()
+      .append('rect')
+      .attr('x', () => x(0))
+      .attr('y', stage => (y(stage.stage) ?? 0))
+      .attr('height', y.bandwidth())
+      .attr('width', stage => x(stage.count) - x(0))
+      .attr('fill', '#f97316')
+  }, [funnel])
+
+  useEffect(() => {
+    const svg = d3.select(heatmapRef.current)
+    svg.selectAll('*').remove()
+
+    if (!heatmap.length) {
+      return
+    }
+
+    const width = 640
+    const height = 240
+    const margin = { top: 20, right: 20, bottom: 40, left: 60 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+
+    const days = Array.from(new Set(heatmap.map(cell => cell.day)))
+    const hours = Array.from(new Set(heatmap.map(cell => cell.hour))).sort((a, b) => a - b)
+
+    const x = d3
+      .scaleBand<number>()
+      .domain(hours)
+      .range([margin.left, width - margin.right])
+      .padding(0.05)
+
+    const y = d3
+      .scaleBand<string>()
+      .domain(days)
+      .range([margin.top, height - margin.bottom])
+      .padding(0.05)
+
+    const maxValue = d3.max(heatmap, cell => cell.value) ?? 1
+    const color = d3.scaleSequential(d3.interpolateYlGnBu).domain([0, maxValue])
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).tickFormat(hour => `${hour}h`))
+
+    svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y))
+
+    svg
+      .selectAll('rect')
+      .data(heatmap)
+      .enter()
+      .append('rect')
+      .attr('x', cell => (x(cell.hour) ?? 0))
+      .attr('y', cell => (y(cell.day) ?? 0))
+      .attr('width', x.bandwidth())
+      .attr('height', y.bandwidth())
+      .attr('rx', 2)
+      .attr('ry', 2)
+      .attr('fill', cell => color(cell.value))
+  }, [heatmap])
+
+  return (
+    <section className="event-analytics" aria-busy={loading}>
+      <header className="event-analytics__header">
+        <div>
+          <h2>Analytique des événements</h2>
+          <p className="event-analytics__subtitle">
+            Synthèse des performances, entonnoir d'approbation et tendances de participation.
+          </p>
+        </div>
+        <div className="event-analytics__controls">
+          <label htmlFor="analytics-range">Période</label>
+          <select
+            id="analytics-range"
+            onChange={event => onRangeChange?.(event.target.value as AnalyticsRangeOption)}
+            value={range}
+            aria-label="Changer la période analytique"
+          >
+            {Object.entries(rangeLabels).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      <div className={`event-analytics__status event-analytics__status--${connectionMeta.tone}`}>
+        {connectionMeta.label}
+        {lastUpdated && (
+          <span className="event-analytics__status-meta">
+            Dernière mise à jour : {new Date(lastUpdated).toLocaleString()}
+          </span>
+        )}
+      </div>
+
+      <div className="event-analytics__cards">
+        <div className="event-analytics__card" data-testid="analytics-total-events">
+          <span className="event-analytics__card-label">Événements totaux</span>
+          <strong>{summary?.totalEvents ?? 0}</strong>
+        </div>
+        <div className="event-analytics__card" data-testid="analytics-published-events">
+          <span className="event-analytics__card-label">Publié</span>
+          <strong>{summary?.published ?? 0}</strong>
+        </div>
+        <div className="event-analytics__card" data-testid="analytics-pending-events">
+          <span className="event-analytics__card-label">En attente</span>
+          <strong>{summary?.pendingApproval ?? 0}</strong>
+        </div>
+        <div className="event-analytics__card" data-testid="analytics-conversion-rate">
+          <span className="event-analytics__card-label">Conversion</span>
+          <strong>{formatPercent(summary?.conversionRate ?? 0)}</strong>
+        </div>
+        <div className="event-analytics__card" data-testid="analytics-attendance-rate">
+          <span className="event-analytics__card-label">Taux de présence</span>
+          <strong>{formatPercent(summary?.averageAttendanceRate ?? 0)}</strong>
+        </div>
+      </div>
+
+      <div className="event-analytics__grid">
+        <article className="event-analytics__panel">
+          <header>
+            <h3>Participation agrégée</h3>
+            <p>Inscriptions vs présence réelle</p>
+          </header>
+          <svg ref={attendanceRef} role="img" aria-label="Tendance des participations" />
+        </article>
+
+        <article className="event-analytics__panel">
+          <header>
+            <h3>Taux de conversion</h3>
+            {topConversion && (
+              <p data-testid={`analytics-conversion-${topConversion.stage}`}>
+                Étape la plus performante : {topConversion.stage} ({topConversion.value})
+              </p>
+            )}
+          </header>
+          <svg ref={conversionRef} role="img" aria-label="Histogramme des conversions" />
+        </article>
+
+        <article className="event-analytics__panel">
+          <header>
+            <h3>Entonnoir d'approbation</h3>
+            <p>Suivi des validations par étape</p>
+          </header>
+          <svg ref={funnelRef} role="img" aria-label="Entonnoir d'approbation" />
+        </article>
+
+        <article className="event-analytics__panel event-analytics__panel--wide">
+          <header>
+            <h3>Heatmap d'engagement</h3>
+            <p>Créneaux horaires les plus actifs</p>
+          </header>
+          <svg ref={heatmapRef} role="img" aria-label="Heatmap d'engagement" />
+        </article>
+      </div>
+    </section>
+  )
+}
+

--- a/src/components/events/EventCategoriesManager.tsx
+++ b/src/components/events/EventCategoriesManager.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react'
+import { EventService, type EventCategory } from '../../services/eventService'
+
+interface EventCategoriesManagerProps {
+  categories: EventCategory[]
+  onCategoriesChange: () => Promise<void> | void
+}
+
+export function EventCategoriesManager({ categories, onCategoriesChange }: EventCategoriesManagerProps) {
+  const [name, setName] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState('')
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!name.trim()) {
+      return
+    }
+    setIsSubmitting(true)
+    try {
+      await EventService.createCategory({ name: name.trim() })
+      setName('')
+      await onCategoriesChange()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleStartEdit = (category: EventCategory) => {
+    setEditingId(category.id)
+    setEditingName(category.name)
+  }
+
+  const handleSaveEdit = async (categoryId: string) => {
+    if (!editingName.trim()) {
+      return
+    }
+    setIsSubmitting(true)
+    try {
+      await EventService.updateCategory(categoryId, { name: editingName.trim() })
+      setEditingId(null)
+      setEditingName('')
+      await onCategoriesChange()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (categoryId: string) => {
+    setIsSubmitting(true)
+    try {
+      await EventService.deleteCategory(categoryId)
+      await onCategoriesChange()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="event-categories">
+      <h3>Gestion des catégories</h3>
+      <form className="event-categories__create" onSubmit={handleCreate}>
+        <input
+          placeholder="Nom de la catégorie"
+          value={name}
+          onChange={event => setName(event.target.value)}
+          disabled={isSubmitting}
+        />
+        <button type="submit" disabled={isSubmitting || name.trim().length === 0}>
+          Ajouter
+        </button>
+      </form>
+      <ul className="event-categories__list">
+        {categories.map(category => (
+          <li key={category.id} className="event-categories__item">
+            {editingId === category.id ? (
+              <>
+                <input value={editingName} onChange={event => setEditingName(event.target.value)} />
+                <button type="button" onClick={() => handleSaveEdit(category.id)} disabled={isSubmitting}>
+                  Enregistrer
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingId(null)
+                    setEditingName('')
+                  }}
+                  disabled={isSubmitting}
+                >
+                  Annuler
+                </button>
+              </>
+            ) : (
+              <>
+                <span className="event-categories__name">{category.name}</span>
+                <button type="button" onClick={() => handleStartEdit(category)} disabled={isSubmitting}>
+                  Renommer
+                </button>
+                <button type="button" onClick={() => handleDelete(category.id)} disabled={isSubmitting}>
+                  Supprimer
+                </button>
+              </>
+            )}
+          </li>
+        ))}
+        {categories.length === 0 && <li>Aucune catégorie disponible</li>}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import type { EventCategory } from '../../services/eventService'
+
+export interface EventFiltersState {
+  search: string
+  status: string
+  categoryId: string
+  startDate: string
+  endDate: string
+}
+
+interface EventFiltersProps {
+  filters: EventFiltersState
+  onChange: (filters: Partial<EventFiltersState>) => void
+  categories: EventCategory[]
+  statuses?: Array<{ value: string; label: string }>
+  disableStatus?: boolean
+}
+
+export function EventFilters({ filters, onChange, categories, statuses, disableStatus }: EventFiltersProps) {
+  const statusOptions =
+    statuses ?? (
+      [
+        { value: '', label: 'Tous les statuts' },
+        { value: 'draft', label: 'Brouillons' },
+        { value: 'pending', label: 'En attente' },
+        { value: 'published', label: 'Publiés' },
+        { value: 'rejected', label: 'Rejetés' },
+        { value: 'archived', label: 'Archivés' }
+      ] as Array<{ value: string; label: string }>
+    )
+
+  return (
+    <section className="event-filters">
+      <div className="event-filters__row">
+        <label className="event-filters__field">
+          <span className="event-filters__label">Recherche</span>
+          <input
+            placeholder="Rechercher un événement"
+            value={filters.search}
+            onChange={e => onChange({ search: e.target.value })}
+          />
+        </label>
+        <label className="event-filters__field">
+          <span className="event-filters__label">Statut</span>
+          <select
+            value={filters.status}
+            disabled={disableStatus}
+            onChange={e => onChange({ status: e.target.value })}
+          >
+            {statusOptions.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="event-filters__field">
+          <span className="event-filters__label">Catégorie</span>
+          <select value={filters.categoryId} onChange={e => onChange({ categoryId: e.target.value })}>
+            <option value="">Toutes les catégories</option>
+            {categories.map(category => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="event-filters__row">
+        <label className="event-filters__field">
+          <span className="event-filters__label">Date de début</span>
+          <input
+            type="date"
+            value={filters.startDate}
+            onChange={e => onChange({ startDate: e.target.value })}
+          />
+        </label>
+        <label className="event-filters__field">
+          <span className="event-filters__label">Date de fin</span>
+          <input type="date" value={filters.endDate} onChange={e => onChange({ endDate: e.target.value })} />
+        </label>
+      </div>
+    </section>
+  )
+}

--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import type { Event, EventCategory, EventInput, EventStatus } from '../../services/eventService'
+
+interface EventFormProps {
+  event?: Event | null
+  categories: EventCategory[]
+  availableTags?: string[]
+  onSave: (payload: EventInput) => Promise<void> | void
+  onCancel: () => void
+}
+
+const STATUS_OPTIONS: Array<{ value: EventStatus; label: string }> = [
+  { value: 'draft', label: 'Brouillon' },
+  { value: 'pending', label: 'En attente' },
+  { value: 'published', label: 'Publié' },
+  { value: 'rejected', label: 'Rejeté' },
+  { value: 'archived', label: 'Archivé' }
+]
+
+export function EventForm({ event, categories, availableTags = [], onSave, onCancel }: EventFormProps) {
+  const [title, setTitle] = useState(event?.title ?? '')
+  const [description, setDescription] = useState(event?.description ?? '')
+  const [status, setStatus] = useState<EventStatus>(event?.status ?? 'draft')
+  const [categoryId, setCategoryId] = useState(event?.categoryId ?? '')
+  const [startDate, setStartDate] = useState(event?.startDate ?? '')
+  const [endDate, setEndDate] = useState(event?.endDate ?? '')
+  const [organizer, setOrganizer] = useState(event?.organizer ?? '')
+  const [location, setLocation] = useState(event?.location ?? '')
+  const [tagsInput, setTagsInput] = useState(event?.tags.join(', ') ?? '')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    setTitle(event?.title ?? '')
+    setDescription(event?.description ?? '')
+    setStatus(event?.status ?? 'draft')
+    setCategoryId(event?.categoryId ?? '')
+    setStartDate(event?.startDate ?? '')
+    setEndDate(event?.endDate ?? '')
+    setOrganizer(event?.organizer ?? '')
+    setLocation(event?.location ?? '')
+    setTagsInput(event?.tags.join(', ') ?? '')
+  }, [event])
+
+  const parsedTags = useMemo(
+    () =>
+      tagsInput
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(Boolean),
+    [tagsInput]
+  )
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    try {
+      const payload: EventInput = {
+        title,
+        description,
+        status,
+        categoryId: categoryId || undefined,
+        startDate,
+        endDate: endDate || undefined,
+        organizer: organizer || undefined,
+        location: location || undefined,
+        tags: parsedTags
+      }
+      await onSave(payload)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const isValid = title.trim().length > 0 && startDate.trim().length > 0
+
+  return (
+    <form className="event-form" onSubmit={handleSubmit}>
+      <h2 className="event-form__title">{event ? 'Modifier un événement' : 'Créer un événement'}</h2>
+      <div className="event-form__grid">
+        <label className="event-form__field">
+          <span>Titre</span>
+          <input value={title} onChange={e => setTitle(e.target.value)} required />
+        </label>
+        <label className="event-form__field">
+          <span>Statut</span>
+          <select value={status} onChange={e => setStatus(e.target.value as EventStatus)}>
+            {STATUS_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="event-form__field">
+          <span>Catégorie</span>
+          <select value={categoryId} onChange={e => setCategoryId(e.target.value)}>
+            <option value="">Aucune catégorie</option>
+            {categories.map(category => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="event-form__field">
+          <span>Organisateur</span>
+          <input value={organizer} onChange={e => setOrganizer(e.target.value)} />
+        </label>
+        <label className="event-form__field">
+          <span>Lieu</span>
+          <input value={location} onChange={e => setLocation(e.target.value)} />
+        </label>
+        <label className="event-form__field">
+          <span>Date de début</span>
+          <input type="datetime-local" value={startDate} onChange={e => setStartDate(e.target.value)} required />
+        </label>
+        <label className="event-form__field">
+          <span>Date de fin</span>
+          <input type="datetime-local" value={endDate} onChange={e => setEndDate(e.target.value)} />
+        </label>
+        <label className="event-form__field event-form__field--wide">
+          <span>Description</span>
+          <textarea value={description} onChange={e => setDescription(e.target.value)} rows={4} />
+        </label>
+        <label className="event-form__field event-form__field--wide">
+          <span>Tags</span>
+          <input
+            value={tagsInput}
+            onChange={e => setTagsInput(e.target.value)}
+            placeholder="tag1, tag2"
+            list="event-form-tags"
+          />
+          <datalist id="event-form-tags">
+            {availableTags.map(tag => (
+              <option key={tag} value={tag} />
+            ))}
+          </datalist>
+        </label>
+      </div>
+      <div className="event-form__actions">
+        <button type="button" onClick={onCancel}>
+          Annuler
+        </button>
+        <button type="submit" disabled={!isValid || isSubmitting}>
+          {isSubmitting ? 'Enregistrement…' : 'Enregistrer'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/events/EventManagement.tsx
+++ b/src/components/events/EventManagement.tsx
@@ -1,9 +1,14 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import {
   Event,
   EventCategory,
   EventInput,
-  EventService
+  EventService,
+  EventAnalyticsSummary,
+  EventAttendanceSeries,
+  EventConversionStat,
+  EventApprovalStage,
+  EventEngagementCell
 } from '../../services/eventService'
 import { EventFilters, EventFiltersState } from './EventFilters'
 import { EventTable } from './EventTable'
@@ -12,6 +17,163 @@ import { EventForm } from './EventForm'
 import { EventCategoriesManager } from './EventCategoriesManager'
 import { useDebounce } from '../../hooks/useDebounce'
 import { usePagination } from '../../hooks/usePagination'
+import { useWebSocket } from '../../hooks/useWebSocket'
+import { EventAnalyticsDashboard, AnalyticsRangeOption } from './EventAnalyticsDashboard'
+
+export interface EventAnalyticsState {
+  summary: EventAnalyticsSummary | null
+  attendance: EventAttendanceSeries[]
+  conversions: EventConversionStat[]
+  funnel: EventApprovalStage[]
+  heatmap: EventEngagementCell[]
+  updatedAt?: string
+}
+
+const defaultSummary: EventAnalyticsSummary = {
+  totalEvents: 0,
+  published: 0,
+  pendingApproval: 0,
+  rejected: 0,
+  averageAttendanceRate: 0,
+  conversionRate: 0
+}
+
+const initialAnalyticsState: EventAnalyticsState = {
+  summary: null,
+  attendance: [],
+  conversions: [],
+  funnel: [],
+  heatmap: [],
+  updatedAt: undefined
+}
+
+type AnalyticsAction =
+  | {
+      type: 'SET_BASELINE'
+      payload: {
+        summary: EventAnalyticsSummary
+        attendance: EventAttendanceSeries[]
+        conversions: EventConversionStat[]
+        funnel: EventApprovalStage[]
+        heatmap: EventEngagementCell[]
+        updatedAt?: string
+      }
+    }
+  | { type: 'PATCH_SUMMARY'; payload: Partial<EventAnalyticsSummary> }
+  | {
+      type: 'UPSERT_ATTENDANCE_POINT'
+      payload: {
+        eventId: string
+        eventName: string
+        date: string
+        registrations: number
+        attendance: number
+      }
+    }
+  | { type: 'UPSERT_CONVERSION'; payload: EventConversionStat }
+  | { type: 'UPSERT_FUNNEL_STAGE'; payload: EventApprovalStage }
+  | { type: 'UPSERT_HEATMAP_CELL'; payload: EventEngagementCell }
+
+export function analyticsReducer(state: EventAnalyticsState, action: AnalyticsAction): EventAnalyticsState {
+  switch (action.type) {
+    case 'SET_BASELINE':
+      return {
+        summary: action.payload.summary,
+        attendance: action.payload.attendance,
+        conversions: action.payload.conversions,
+        funnel: action.payload.funnel,
+        heatmap: action.payload.heatmap,
+        updatedAt: action.payload.updatedAt ?? new Date().toISOString()
+      }
+    case 'PATCH_SUMMARY': {
+      const nextSummary = { ...(state.summary ?? defaultSummary), ...action.payload }
+      return {
+        ...state,
+        summary: nextSummary,
+        updatedAt: new Date().toISOString()
+      }
+    }
+    case 'UPSERT_ATTENDANCE_POINT': {
+      const { eventId, eventName, date, registrations, attendance } = action.payload
+      const nextAttendance = state.attendance.map(series => ({ ...series, series: [...series.series] }))
+      const existingSeriesIndex = nextAttendance.findIndex(series => series.eventId === eventId)
+
+      if (existingSeriesIndex === -1) {
+        nextAttendance.push({
+          eventId,
+          eventName,
+          series: [{ date, registrations, attendance }]
+        })
+      } else {
+        const existingSeries = nextAttendance[existingSeriesIndex]
+        const points = [...existingSeries.series]
+        const pointIndex = points.findIndex(point => point.date === date)
+        const nextPoint = { date, registrations, attendance }
+
+        if (pointIndex === -1) {
+          points.push(nextPoint)
+        } else {
+          points[pointIndex] = nextPoint
+        }
+
+        points.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+        nextAttendance[existingSeriesIndex] = { ...existingSeries, eventName, series: points }
+      }
+
+      return {
+        ...state,
+        attendance: nextAttendance,
+        updatedAt: new Date().toISOString()
+      }
+    }
+    case 'UPSERT_CONVERSION': {
+      const index = state.conversions.findIndex(item => item.stage === action.payload.stage)
+      const nextConversions = [...state.conversions]
+      if (index === -1) {
+        nextConversions.push(action.payload)
+      } else {
+        nextConversions[index] = action.payload
+      }
+      return {
+        ...state,
+        conversions: nextConversions,
+        updatedAt: new Date().toISOString()
+      }
+    }
+    case 'UPSERT_FUNNEL_STAGE': {
+      const index = state.funnel.findIndex(stage => stage.stage === action.payload.stage)
+      const nextFunnel = [...state.funnel]
+      if (index === -1) {
+        nextFunnel.push(action.payload)
+      } else {
+        nextFunnel[index] = action.payload
+      }
+      return {
+        ...state,
+        funnel: nextFunnel,
+        updatedAt: new Date().toISOString()
+      }
+    }
+    case 'UPSERT_HEATMAP_CELL': {
+      const index = state.heatmap.findIndex(
+        cell => cell.day === action.payload.day && cell.hour === action.payload.hour
+      )
+      const nextHeatmap = [...state.heatmap]
+      if (index === -1) {
+        nextHeatmap.push(action.payload)
+      } else {
+        nextHeatmap[index] = action.payload
+      }
+      return {
+        ...state,
+        heatmap: nextHeatmap,
+        updatedAt: new Date().toISOString()
+      }
+    }
+    default:
+      return state
+  }
+}
 
 interface EventManagementProps {
   initialFilters?: Partial<EventFiltersState>
@@ -40,6 +202,10 @@ export function EventManagement({ initialFilters, lockedStatus }: EventManagemen
   const [editingEvent, setEditingEvent] = useState<Event | null>(null)
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [isCategoriesOpen, setIsCategoriesOpen] = useState(false)
+  const [analyticsRange, setAnalyticsRange] = useState<AnalyticsRangeOption>('30d')
+  const [analyticsLoading, setAnalyticsLoading] = useState(false)
+
+  const [analyticsState, dispatchAnalytics] = useReducer(analyticsReducer, initialAnalyticsState)
 
   const debouncedSearch = useDebounce(filters.search)
   const { page, pageSize, setPage } = usePagination(20)
@@ -112,6 +278,133 @@ export function EventManagement({ initialFilters, lockedStatus }: EventManagemen
     loadCategories()
     loadTags()
   }, [loadCategories, loadTags])
+
+  const loadAnalytics = useCallback(async (range: AnalyticsRangeOption) => {
+    setAnalyticsLoading(true)
+    try {
+      const [summary, attendanceSeries, conversionSeries, funnelSeries, heatmapSeries] =
+        await Promise.all([
+          EventService.getAnalyticsSummary({ range }),
+          EventService.getAttendanceAnalytics({ range }),
+          EventService.getConversionAnalytics({ range }),
+          EventService.getApprovalFunnel({ range }),
+          EventService.getEngagementHeatmap({ range })
+        ])
+
+      dispatchAnalytics({
+        type: 'SET_BASELINE',
+        payload: {
+          summary,
+          attendance: attendanceSeries,
+          conversions: conversionSeries,
+          funnel: funnelSeries,
+          heatmap: heatmapSeries,
+          updatedAt: new Date().toISOString()
+        }
+      })
+    } catch (error) {
+      console.error('Failed to load event analytics', error)
+    } finally {
+      setAnalyticsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadAnalytics(analyticsRange)
+  }, [analyticsRange, loadAnalytics])
+
+  const analyticsSocketUrl = useMemo(() => {
+    const wsBase = (import.meta.env.VITE_WS_BASE_URL as string | undefined)?.replace(/\/$/, '')
+    if (wsBase) {
+      return `${wsBase}/events`
+    }
+    const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '')
+    if (!apiBase) {
+      return null
+    }
+    if (apiBase.startsWith('http')) {
+      return `${apiBase.replace(/^http/, 'ws')}/ws/events`
+    }
+    return `ws://${apiBase}/ws/events`
+  }, [])
+
+  const { readyState: analyticsSocketState, subscribe: subscribeToAnalyticsStream } = useWebSocket(
+    analyticsSocketUrl,
+    {
+      enabled: Boolean(analyticsSocketUrl),
+      reconnectInterval: 4000,
+      maxReconnectInterval: 30000
+    }
+  )
+
+  useEffect(() => {
+    if (!analyticsSocketUrl) {
+      return undefined
+    }
+    return subscribeToAnalyticsStream(event => {
+      try {
+        const message = JSON.parse(event.data as string)
+        if (!message || typeof message !== 'object') {
+          return
+        }
+        switch (message.type) {
+          case 'summary':
+            dispatchAnalytics({ type: 'PATCH_SUMMARY', payload: message.data ?? {} })
+            break
+          case 'registration':
+            if (!message.eventId || !message.date) {
+              break
+            }
+            dispatchAnalytics({
+              type: 'UPSERT_ATTENDANCE_POINT',
+              payload: {
+                eventId: message.eventId,
+                eventName: message.eventName,
+                date: message.date,
+                registrations: message.registrations,
+                attendance: message.attendance
+              }
+            })
+            break
+          case 'conversion':
+            if (!message.stage) {
+              break
+            }
+            dispatchAnalytics({
+              type: 'UPSERT_CONVERSION',
+              payload: { stage: message.stage, value: message.value }
+            })
+            break
+          case 'approval':
+            if (!message.stage) {
+              break
+            }
+            dispatchAnalytics({
+              type: 'UPSERT_FUNNEL_STAGE',
+              payload: { stage: message.stage, count: message.count }
+            })
+            break
+          case 'heatmap':
+            if (!message.day || typeof message.hour !== 'number') {
+              break
+            }
+            dispatchAnalytics({
+              type: 'UPSERT_HEATMAP_CELL',
+              payload: { day: message.day, hour: message.hour, value: message.value }
+            })
+            break
+          default:
+            console.warn('Unhandled analytics event', message)
+        }
+      } catch (error) {
+        console.error('Failed to parse analytics update', error)
+      }
+    })
+  }, [subscribeToAnalyticsStream])
+
+  const handleAnalyticsRangeChange = (range: AnalyticsRangeOption) => {
+    setAnalyticsRange(range)
+  }
 
   useEffect(() => {
     const refresh = async () => {
@@ -201,10 +494,23 @@ export function EventManagement({ initialFilters, lockedStatus }: EventManagemen
     if (res) {
       ensurePageWithinBounds(res.total)
     }
+    await loadAnalytics(analyticsRange)
   }
 
   return (
     <div className="event-management">
+      <EventAnalyticsDashboard
+        summary={analyticsState.summary}
+        attendance={analyticsState.attendance}
+        conversions={analyticsState.conversions}
+        funnel={analyticsState.funnel}
+        heatmap={analyticsState.heatmap}
+        loading={analyticsLoading}
+        lastUpdated={analyticsState.updatedAt}
+        connectionState={analyticsSocketState}
+        onRangeChange={handleAnalyticsRangeChange}
+        range={analyticsRange}
+      />
       <EventFilters
         filters={filters}
         onChange={handleFilterChange}

--- a/src/components/events/EventManagement.tsx
+++ b/src/components/events/EventManagement.tsx
@@ -1,0 +1,249 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Event,
+  EventCategory,
+  EventInput,
+  EventService
+} from '../../services/eventService'
+import { EventFilters, EventFiltersState } from './EventFilters'
+import { EventTable } from './EventTable'
+import { EventActionsBar } from './EventActionsBar'
+import { EventForm } from './EventForm'
+import { EventCategoriesManager } from './EventCategoriesManager'
+import { useDebounce } from '../../hooks/useDebounce'
+import { usePagination } from '../../hooks/usePagination'
+
+interface EventManagementProps {
+  initialFilters?: Partial<EventFiltersState>
+  lockedStatus?: string
+}
+
+export function EventManagement({ initialFilters, lockedStatus }: EventManagementProps) {
+  const initialState = useMemo<EventFiltersState>(
+    () => ({
+      search: initialFilters?.search ?? '',
+      status: lockedStatus ?? initialFilters?.status ?? '',
+      categoryId: initialFilters?.categoryId ?? '',
+      startDate: initialFilters?.startDate ?? '',
+      endDate: initialFilters?.endDate ?? ''
+    }),
+    [initialFilters, lockedStatus]
+  )
+
+  const [events, setEvents] = useState<Event[]>([])
+  const [total, setTotal] = useState(0)
+  const [filters, setFilters] = useState<EventFiltersState>(initialState)
+  const [categories, setCategories] = useState<EventCategory[]>([])
+  const [availableTags, setAvailableTags] = useState<string[]>([])
+  const [selected, setSelected] = useState<string[]>([])
+  const [selectionResetKey, setSelectionResetKey] = useState(0)
+  const [editingEvent, setEditingEvent] = useState<Event | null>(null)
+  const [isFormOpen, setIsFormOpen] = useState(false)
+  const [isCategoriesOpen, setIsCategoriesOpen] = useState(false)
+
+  const debouncedSearch = useDebounce(filters.search)
+  const { page, pageSize, setPage } = usePagination(20)
+
+  const requestIdRef = useRef(0)
+
+  useEffect(() => {
+    if (lockedStatus && filters.status !== lockedStatus) {
+      setFilters(prev => ({ ...prev, status: lockedStatus }))
+    }
+  }, [filters.status, lockedStatus])
+
+  const loadEvents = useCallback(async () => {
+    const requestId = requestIdRef.current + 1
+    requestIdRef.current = requestId
+
+    const res = await EventService.list({
+      page,
+      pageSize,
+      search: debouncedSearch,
+      status: lockedStatus ?? filters.status,
+      categoryId: filters.categoryId,
+      startDate: filters.startDate,
+      endDate: filters.endDate
+    })
+
+    if (requestId !== requestIdRef.current) {
+      return null
+    }
+
+    setEvents(res.events)
+    setTotal(res.total)
+    return res
+  }, [
+    page,
+    pageSize,
+    debouncedSearch,
+    filters.status,
+    filters.categoryId,
+    filters.startDate,
+    filters.endDate,
+    lockedStatus
+  ])
+
+  const ensurePageWithinBounds = useCallback(
+    (count: number) => {
+      const maxPage = Math.max(0, Math.ceil(count / pageSize) - 1)
+      if (page > maxPage) {
+        setPage(maxPage)
+      }
+    },
+    [page, pageSize, setPage]
+  )
+
+  const loadCategories = useCallback(async () => {
+    const data = await EventService.listCategories()
+    setCategories(data)
+  }, [])
+
+  const loadTags = useCallback(async () => {
+    try {
+      const data = await EventService.listTags()
+      setAvailableTags(data)
+    } catch (error) {
+      console.error('Failed to load event tags', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadCategories()
+    loadTags()
+  }, [loadCategories, loadTags])
+
+  useEffect(() => {
+    const refresh = async () => {
+      const res = await loadEvents()
+      if (res) {
+        ensurePageWithinBounds(res.total)
+      }
+    }
+
+    refresh()
+  }, [loadEvents, ensurePageWithinBounds])
+
+  const handleFilterChange = (partial: Partial<EventFiltersState>) => {
+    setFilters(prev => {
+      const next = { ...prev, ...partial }
+      if (lockedStatus) {
+        next.status = lockedStatus
+      }
+      return next
+    })
+    setPage(0)
+  }
+
+  const handleBulkAction = async (action: 'approve' | 'reject' | 'archive') => {
+    if (selected.length === 0) {
+      return
+    }
+    await EventService.bulk(selected, action)
+    setSelected([])
+    setSelectionResetKey(prev => prev + 1)
+    const res = await loadEvents()
+    if (res) {
+      ensurePageWithinBounds(res.total)
+    }
+  }
+
+  const handleApplyTags = async (tags: string[]) => {
+    if (selected.length === 0 || tags.length === 0) {
+      return
+    }
+    await EventService.bulkTags(selected, tags)
+    setSelected([])
+    setSelectionResetKey(prev => prev + 1)
+    const res = await loadEvents()
+    if (res) {
+      ensurePageWithinBounds(res.total)
+    }
+    await loadTags()
+  }
+
+  const handleCreate = () => {
+    setEditingEvent(null)
+    setIsFormOpen(true)
+  }
+
+  const handleEdit = (event: Event) => {
+    setEditingEvent(event)
+    setIsFormOpen(true)
+  }
+
+  const handleSave = async (payload: EventInput) => {
+    if (editingEvent) {
+      await EventService.update(editingEvent.id, payload)
+    } else {
+      await EventService.create(payload)
+    }
+    setIsFormOpen(false)
+    setEditingEvent(null)
+    const res = await loadEvents()
+    if (res) {
+      ensurePageWithinBounds(res.total)
+    }
+    await loadTags()
+  }
+
+  const handleCancelForm = () => {
+    setIsFormOpen(false)
+    setEditingEvent(null)
+  }
+
+  const handleToggleCategories = () => {
+    setIsCategoriesOpen(open => !open)
+  }
+
+  const handleRefresh = async () => {
+    const res = await loadEvents()
+    if (res) {
+      ensurePageWithinBounds(res.total)
+    }
+  }
+
+  return (
+    <div className="event-management">
+      <EventFilters
+        filters={filters}
+        onChange={handleFilterChange}
+        categories={categories}
+        disableStatus={Boolean(lockedStatus)}
+      />
+      <EventActionsBar
+        selected={selected}
+        onApprove={() => handleBulkAction('approve')}
+        onReject={() => handleBulkAction('reject')}
+        onArchive={() => handleBulkAction('archive')}
+        onCreate={handleCreate}
+        onManageCategories={handleToggleCategories}
+        onRefresh={handleRefresh}
+        onApplyTags={handleApplyTags}
+        availableTags={availableTags}
+      />
+      {isFormOpen && (
+        <EventForm
+          event={editingEvent}
+          categories={categories}
+          availableTags={availableTags}
+          onSave={handleSave}
+          onCancel={handleCancelForm}
+        />
+      )}
+      {isCategoriesOpen && (
+        <EventCategoriesManager categories={categories} onCategoriesChange={loadCategories} />
+      )}
+      <EventTable
+        data={events}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={setPage}
+        onSelect={setSelected}
+        onEdit={handleEdit}
+        clearSelectionKey={selectionResetKey}
+      />
+    </div>
+  )
+}

--- a/src/components/events/EventTable.tsx
+++ b/src/components/events/EventTable.tsx
@@ -1,0 +1,162 @@
+import React from 'react'
+import {
+  useReactTable,
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel
+} from '@tanstack/react-table'
+import type { Event } from '../../services/eventService'
+
+interface EventTableProps {
+  data: Event[]
+  total: number
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onSelect: (ids: string[]) => void
+  onEdit: (event: Event) => void
+  clearSelectionKey?: number
+}
+
+export function EventTable({
+  data,
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  onSelect,
+  onEdit,
+  clearSelectionKey
+}: EventTableProps) {
+  const [rowSelection, setRowSelection] = React.useState({})
+
+  const columns = React.useMemo<ColumnDef<Event>[]>(
+    () => [
+      {
+        id: 'select',
+        header: ({ table }) => (
+          <input
+            type="checkbox"
+            checked={table.getIsAllPageRowsSelected()}
+            onChange={table.getToggleAllPageRowsSelectedHandler()}
+          />
+        ),
+        cell: ({ row }) => (
+          <input
+            type="checkbox"
+            checked={row.getIsSelected()}
+            disabled={!row.getCanSelect()}
+            onChange={row.getToggleSelectedHandler()}
+          />
+        )
+      },
+      {
+        accessorKey: 'title',
+        header: 'Titre'
+      },
+      {
+        accessorKey: 'status',
+        header: 'Statut'
+      },
+      {
+        id: 'category',
+        header: 'Catégorie',
+        cell: ({ row }) => row.original.category?.name ?? '—'
+      },
+      {
+        accessorKey: 'startDate',
+        header: 'Début'
+      },
+      {
+        accessorKey: 'endDate',
+        header: 'Fin'
+      },
+      {
+        id: 'tags',
+        header: 'Tags',
+        cell: ({ row }) => (row.original.tags.length ? row.original.tags.join(', ') : '—')
+      },
+      {
+        id: 'actions',
+        header: 'Actions',
+        cell: ({ row }) => (
+          <button type="button" onClick={() => onEdit(row.original)}>
+            Modifier
+          </button>
+        )
+      }
+    ],
+    [onEdit]
+  )
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { rowSelection },
+    enableRowSelection: true,
+    getRowId: row => row.id,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel()
+  })
+
+  React.useEffect(() => {
+    if (clearSelectionKey !== undefined) {
+      setRowSelection({})
+    }
+  }, [clearSelectionKey])
+
+  React.useEffect(() => {
+    onSelect(table.getSelectedRowModel().rows.map(row => row.original.id))
+  }, [rowSelection, onSelect, table])
+
+  const safePageSize = pageSize > 0 ? pageSize : 1
+  const pageCount = Math.max(1, Math.ceil(total / safePageSize))
+  const hasPages = total > 0
+  const canGoPrev = hasPages && page > 0
+  const canGoNext = hasPages && page + 1 < pageCount
+
+  return (
+    <section className="event-table">
+      <table>
+        <thead>
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map(header => (
+                <th key={header.id} onClick={header.column.getToggleSortingHandler() as any}>
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map(row => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+              ))}
+            </tr>
+          ))}
+          {table.getRowModel().rows.length === 0 && (
+            <tr>
+              <td colSpan={columns.length} style={{ textAlign: 'center', padding: '12px' }}>
+                Aucun événement trouvé
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <div className="pagination">
+        <button type="button" disabled={!canGoPrev} onClick={() => canGoPrev && onPageChange(page - 1)}>
+          Précédent
+        </button>
+        <span>{hasPages ? `Page ${page + 1} / ${pageCount}` : 'Aucune page'}</span>
+        <button type="button" disabled={!canGoNext} onClick={() => canGoNext && onPageChange(page + 1)}>
+          Suivant
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,132 @@
+import React, { useMemo } from 'react'
+import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { usePermissions } from '../../hooks/usePermissions'
+import { ADMIN_MODULES } from '../../utils/adminNavigation'
+
+const layoutStyle: React.CSSProperties = {
+  display: 'flex',
+  minHeight: '100vh',
+  backgroundColor: '#f3f4f6'
+}
+
+const sidebarStyle: React.CSSProperties = {
+  width: '260px',
+  backgroundColor: '#111827',
+  color: '#fff',
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '24px 16px',
+  boxSizing: 'border-box'
+}
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '16px 24px',
+  backgroundColor: '#fff',
+  borderBottom: '1px solid #e5e7eb'
+}
+
+const mainStyle: React.CSSProperties = {
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column'
+}
+
+const contentStyle: React.CSSProperties = {
+  padding: '24px',
+  flex: 1
+}
+
+const navLinkBaseStyle: React.CSSProperties = {
+  color: '#e5e7eb',
+  padding: '10px 14px',
+  borderRadius: '8px',
+  textDecoration: 'none',
+  fontWeight: 500,
+  marginBottom: '6px',
+  display: 'block'
+}
+
+const navLinkActiveStyle: React.CSSProperties = {
+  ...navLinkBaseStyle,
+  backgroundColor: '#1f2937',
+  color: '#fff'
+}
+
+const breadcrumbNavStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: '0.875rem',
+  color: '#6b7280'
+}
+
+export function AdminLayout() {
+  const location = useLocation()
+  const { admin } = usePermissions()
+
+  const labelMap = useMemo(() => {
+    const map = new Map<string, string>()
+    map.set('admin', 'Administration')
+    ADMIN_MODULES.forEach(module => {
+      map.set(module.path, module.label)
+    })
+    return map
+  }, [])
+
+  const breadcrumbs = useMemo(() => {
+    const segments = location.pathname.split('/').filter(Boolean)
+    let currentPath = ''
+
+    return segments.map(segment => {
+      currentPath += `/${segment}`
+      const label = labelMap.get(segment) || segment
+      return { path: currentPath, label }
+    })
+  }, [labelMap, location.pathname])
+
+  return (
+    <div style={layoutStyle}>
+      <aside style={sidebarStyle}>
+        <div style={{ marginBottom: '32px' }}>
+          <span style={{ fontSize: '1.25rem', fontWeight: 700 }}>Meetinity Admin</span>
+        </div>
+        <nav aria-label="Navigation principale">
+          {ADMIN_MODULES.map(module => (
+            <NavLink
+              key={module.path}
+              to={`/admin/${module.path}`}
+              style={({ isActive }) => (isActive ? navLinkActiveStyle : navLinkBaseStyle)}
+            >
+              <div style={{ fontWeight: 600 }}>{module.label}</div>
+              <div style={{ fontSize: '0.75rem', color: '#9ca3af' }}>{module.description}</div>
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+      <div style={mainStyle}>
+        <header style={headerStyle}>
+          <div>
+            <h1 style={{ margin: 0, fontSize: '1.5rem' }}>Tableau de bord</h1>
+            <nav aria-label="Fil d'Ariane" style={breadcrumbNavStyle}>
+              {breadcrumbs.map((crumb, index) => (
+                <React.Fragment key={crumb.path}>
+                  {index > 0 && <span style={{ margin: '0 8px' }}>/</span>}
+                  <span>{crumb.label}</span>
+                </React.Fragment>
+              ))}
+            </nav>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontWeight: 600 }}>{admin?.name || 'Administrateur'}</div>
+            <div style={{ fontSize: '0.875rem', color: '#6b7280' }}>{admin?.email}</div>
+          </div>
+        </header>
+        <main style={contentStyle}>
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -88,7 +88,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     [admin, permissions, roles, isLoading, error, hasPermissions]
   )
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  return React.createElement(AuthContext.Provider, { value }, children)
 }
 
 export const usePermissions = () => {

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,0 +1,102 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
+import { AuthService, AuthServiceError, AdminSession } from '../services/authService'
+
+interface AuthContextValue {
+  admin: AdminSession | null
+  permissions: string[]
+  roles: string[]
+  isLoading: boolean
+  error: string | null
+  hasPermissions: (required?: string[]) => boolean
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [admin, setAdmin] = useState<AdminSession | null>(null)
+  const [permissions, setPermissions] = useState<string[]>([])
+  const [roles, setRoles] = useState<string[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const load = async () => {
+      try {
+        const [session, permissionsResponse] = await Promise.all([
+          AuthService.getSession(),
+          AuthService.getPermissions()
+        ])
+
+        if (!isMounted) {
+          return
+        }
+
+        if (!session || !permissionsResponse) {
+          throw new AuthServiceError('Session administrateur invalide.')
+        }
+
+        setAdmin(session)
+        setPermissions(permissionsResponse.permissions || [])
+        setRoles(permissionsResponse.roles || [])
+        setError(null)
+      } catch (err) {
+        if (!isMounted) {
+          return
+        }
+
+        const message = err instanceof AuthServiceError ? err.message : 'Accès refusé.'
+        setAdmin(null)
+        setPermissions([])
+        setRoles([])
+        setError(message)
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    load()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const hasPermissions = useCallback(
+    (required?: string[]) => {
+      if (!required || required.length === 0) {
+        return true
+      }
+
+      return required.every(permission => permissions.includes(permission))
+    },
+    [permissions]
+  )
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ admin, permissions, roles, isLoading, error, hasPermissions }),
+    [admin, permissions, roles, isLoading, error, hasPermissions]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export const usePermissions = () => {
+  const context = useContext(AuthContext)
+
+  if (!context) {
+    throw new Error('usePermissions doit être utilisé dans un AuthProvider')
+  }
+
+  return context
+}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export type WebSocketMessageHandler = (event: MessageEvent) => void
+
+export interface UseWebSocketOptions {
+  enabled?: boolean
+  protocols?: string | string[]
+  reconnectInterval?: number
+  maxReconnectInterval?: number
+  shouldReconnect?: (event: CloseEvent) => boolean
+  onOpen?: (event: Event) => void
+  onClose?: (event: CloseEvent) => void
+  onError?: (event: Event) => void
+}
+
+export interface UseWebSocketResult {
+  readyState: number
+  connectionAttempts: number
+  subscribe: (handler: WebSocketMessageHandler) => () => void
+  send: (data: Parameters<WebSocket['send']>[0]) => void
+  close: () => void
+}
+
+const READY_STATE_UNINSTANTIATED = typeof WebSocket === 'undefined' ? 3 : WebSocket.CLOSED
+const WS_OPEN_STATE = typeof WebSocket === 'undefined' ? 1 : WebSocket.OPEN
+
+export function useWebSocket(url: string | null, options: UseWebSocketOptions = {}): UseWebSocketResult {
+  const {
+    enabled = true,
+    protocols,
+    reconnectInterval = 2000,
+    maxReconnectInterval = 15000,
+    shouldReconnect,
+    onOpen,
+    onClose,
+    onError
+  } = options
+
+  const socketRef = useRef<WebSocket | null>(null)
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const manualCloseRef = useRef(false)
+  const attemptsRef = useRef(0)
+  const handlersRef = useRef(new Set<WebSocketMessageHandler>())
+  const [readyState, setReadyState] = useState<number>(READY_STATE_UNINSTANTIATED)
+  const [connectionAttempts, setConnectionAttempts] = useState(0)
+
+  const clearReconnectTimeout = () => {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current)
+      reconnectTimeoutRef.current = null
+    }
+  }
+
+  const subscribe = useCallback((handler: WebSocketMessageHandler) => {
+    handlersRef.current.add(handler)
+    return () => {
+      handlersRef.current.delete(handler)
+    }
+  }, [])
+
+  const send = useCallback((data: Parameters<WebSocket['send']>[0]) => {
+    const socket = socketRef.current
+    if (!socket || socket.readyState !== WS_OPEN_STATE) {
+      throw new Error('Cannot send message while socket is not open')
+    }
+    socket.send(data)
+  }, [])
+
+  const close = useCallback(() => {
+    manualCloseRef.current = true
+    clearReconnectTimeout()
+    socketRef.current?.close()
+  }, [])
+
+  useEffect(() => {
+    if (!url || !enabled || typeof WebSocket === 'undefined') {
+      return undefined
+    }
+
+    manualCloseRef.current = false
+
+    const connect = () => {
+      clearReconnectTimeout()
+
+      try {
+        const socket = new WebSocket(url, protocols)
+        socketRef.current = socket
+        setReadyState(socket.readyState)
+        attemptsRef.current += 1
+        setConnectionAttempts(attemptsRef.current)
+
+        socket.onopen = event => {
+          attemptsRef.current = 0
+          setReadyState(socket.readyState)
+          setConnectionAttempts(0)
+          onOpen?.(event)
+        }
+
+        socket.onmessage = event => {
+          handlersRef.current.forEach(handler => handler(event))
+        }
+
+        socket.onerror = event => {
+          onError?.(event)
+        }
+
+        socket.onclose = event => {
+          setReadyState(socket.readyState)
+          onClose?.(event)
+
+          const allowReconnect =
+            !manualCloseRef.current &&
+            enabled &&
+            (shouldReconnect ? shouldReconnect(event) : event.code !== 1000)
+
+          if (!allowReconnect) {
+            return
+          }
+
+          const nextDelay = Math.min(
+            maxReconnectInterval,
+            reconnectInterval * Math.max(1, attemptsRef.current)
+          )
+
+          reconnectTimeoutRef.current = setTimeout(() => {
+            if (manualCloseRef.current) {
+              return
+            }
+            connect()
+          }, nextDelay)
+        }
+      } catch (error) {
+        console.error('Failed to initialise WebSocket connection', error)
+      }
+    }
+
+    connect()
+
+    return () => {
+      manualCloseRef.current = true
+      clearReconnectTimeout()
+      socketRef.current?.close()
+      socketRef.current = null
+    }
+  }, [url, enabled, protocols, reconnectInterval, maxReconnectInterval, shouldReconnect, onOpen, onClose, onError])
+
+  return {
+    readyState,
+    connectionAttempts,
+    subscribe,
+    send,
+    close
+  }
+}
+

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,60 @@
+import axios, { AxiosError } from 'axios'
+
+const API = import.meta.env.VITE_API_BASE_URL
+
+export interface AdminSession {
+  id: string
+  email: string
+  name: string
+  role: string
+}
+
+export interface AdminPermissionsResponse {
+  permissions: string[]
+  roles?: string[]
+}
+
+export class AuthServiceError extends Error {
+  constructor(message: string, public status?: number) {
+    super(message)
+    this.name = 'AuthServiceError'
+  }
+}
+
+const normalizeError = (error: unknown): never => {
+  if (axios.isAxiosError(error)) {
+    const axiosError = error as AxiosError<{ message?: string }>
+    const message =
+      axiosError.response?.data?.message ||
+      axiosError.message ||
+      'Une erreur est survenue lors de la vérification de la session.'
+
+    throw new AuthServiceError(message, axiosError.response?.status)
+  }
+
+  if (error instanceof Error) {
+    throw new AuthServiceError(error.message)
+  }
+
+  throw new AuthServiceError('Une erreur inattendue est survenue.')
+}
+
+export const AuthService = {
+  async getSession() {
+    try {
+      const { data } = await axios.get(`${API}/api/admin/me`)
+      return data as AdminSession
+    } catch (error) {
+      return normalizeError(error)
+    }
+  },
+
+  async getPermissions() {
+    try {
+      const { data } = await axios.get(`${API}/api/admin/permissions`)
+      return data as AdminPermissionsResponse
+    } catch (error) {
+      return normalizeError(error)
+    }
+  }
+}

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -55,6 +55,49 @@ export interface EventCategoryInput {
   color?: string
 }
 
+export interface EventAnalyticsQuery {
+  range?: '7d' | '14d' | '30d' | '90d'
+  startDate?: string
+  endDate?: string
+}
+
+export interface EventAnalyticsSummary {
+  totalEvents: number
+  published: number
+  pendingApproval: number
+  rejected: number
+  averageAttendanceRate: number
+  conversionRate: number
+}
+
+export interface EventAttendancePoint {
+  date: string
+  registrations: number
+  attendance: number
+}
+
+export interface EventAttendanceSeries {
+  eventId: string
+  eventName: string
+  series: EventAttendancePoint[]
+}
+
+export interface EventConversionStat {
+  stage: string
+  value: number
+}
+
+export interface EventApprovalStage {
+  stage: string
+  count: number
+}
+
+export interface EventEngagementCell {
+  day: string
+  hour: number
+  value: number
+}
+
 const API = import.meta.env.VITE_API_BASE_URL
 
 export const EventService = {
@@ -113,5 +156,27 @@ export const EventService = {
   },
   async deleteCategory(id: string) {
     await axios.delete(`${API}/api/events/categories/${id}`)
+  },
+  async getAnalyticsSummary(params?: EventAnalyticsQuery) {
+    const { data } = await axios.get(`${API}/api/events/analytics`, { params })
+    return data as EventAnalyticsSummary
+  },
+  async getAttendanceAnalytics(params?: EventAnalyticsQuery) {
+    const { data } = await axios.get(`${API}/api/events/attendance`, { params })
+    return data as EventAttendanceSeries[]
+  },
+  async getConversionAnalytics(params?: EventAnalyticsQuery) {
+    const { data } = await axios.get(`${API}/api/events/conversions`, { params })
+    return data as EventConversionStat[]
+  },
+  async getApprovalFunnel(params?: EventAnalyticsQuery) {
+    const { data } = await axios.get(`${API}/api/events/approval-funnel`, { params })
+    return data as EventApprovalStage[]
+  },
+  async getEngagementHeatmap(params?: EventAnalyticsQuery) {
+    const { data } = await axios.get(`${API}/api/events/engagement-heatmap`, {
+      params
+    })
+    return data as EventEngagementCell[]
   }
 }

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,0 +1,117 @@
+import axios from 'axios'
+
+export type EventStatus = 'draft' | 'pending' | 'published' | 'rejected' | 'archived'
+
+export interface EventCategory {
+  id: string
+  name: string
+  description?: string
+  color?: string
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface Event {
+  id: string
+  title: string
+  description?: string
+  status: EventStatus
+  categoryId?: string
+  category?: EventCategory
+  startDate: string
+  endDate?: string
+  organizer?: string
+  location?: string
+  tags: string[]
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface EventListParams {
+  page?: number
+  pageSize?: number
+  search?: string
+  status?: string
+  categoryId?: string
+  startDate?: string
+  endDate?: string
+}
+
+export interface EventInput {
+  title: string
+  description?: string
+  status?: EventStatus
+  categoryId?: string
+  startDate: string
+  endDate?: string
+  organizer?: string
+  location?: string
+  tags?: string[]
+}
+
+export interface EventCategoryInput {
+  name: string
+  description?: string
+  color?: string
+}
+
+const API = import.meta.env.VITE_API_BASE_URL
+
+export const EventService = {
+  async list(params: EventListParams) {
+    const { data } = await axios.get(`${API}/api/events`, { params })
+    return data as { events: Event[]; total: number }
+  },
+  async get(id: string) {
+    const { data } = await axios.get(`${API}/api/events/${id}`)
+    return data as Event
+  },
+  async create(payload: EventInput) {
+    const { data } = await axios.post(`${API}/api/events`, payload)
+    return data as Event
+  },
+  async update(id: string, payload: EventInput) {
+    const { data } = await axios.put(`${API}/api/events/${id}`, payload)
+    return data as Event
+  },
+  async remove(id: string) {
+    await axios.delete(`${API}/api/events/${id}`)
+  },
+  async approve(id: string, notes?: string) {
+    await axios.post(`${API}/api/events/${id}/approve`, { notes })
+  },
+  async reject(id: string, reason?: string) {
+    await axios.post(`${API}/api/events/${id}/reject`, { reason })
+  },
+  async archive(id: string) {
+    await axios.post(`${API}/api/events/${id}/archive`)
+  },
+  async bulk(ids: string[], action: 'approve' | 'reject' | 'archive') {
+    await axios.post(`${API}/api/events/bulk`, { ids, action })
+  },
+  async bulkTags(ids: string[], tags: string[]) {
+    await axios.post(`${API}/api/events/bulk-tags`, { ids, tags })
+  },
+  async updateTags(id: string, tags: string[]) {
+    await axios.put(`${API}/api/events/${id}/tags`, { tags })
+  },
+  async listTags() {
+    const { data } = await axios.get(`${API}/api/events/tags`)
+    return data as string[]
+  },
+  async listCategories() {
+    const { data } = await axios.get(`${API}/api/events/categories`)
+    return data as EventCategory[]
+  },
+  async createCategory(payload: EventCategoryInput) {
+    const { data } = await axios.post(`${API}/api/events/categories`, payload)
+    return data as EventCategory
+  },
+  async updateCategory(id: string, payload: EventCategoryInput) {
+    const { data } = await axios.put(`${API}/api/events/categories/${id}`, payload)
+    return data as EventCategory
+  },
+  async deleteCategory(id: string) {
+    await axios.delete(`${API}/api/events/categories/${id}`)
+  }
+}

--- a/src/utils/adminNavigation.ts
+++ b/src/utils/adminNavigation.ts
@@ -1,0 +1,39 @@
+export interface AdminModuleConfig {
+  path: string
+  label: string
+  requiredPermissions: string[]
+  description?: string
+}
+
+export const ADMIN_MODULES: AdminModuleConfig[] = [
+  {
+    path: 'users',
+    label: 'Utilisateurs',
+    requiredPermissions: ['users:read'],
+    description: 'Gérez les comptes utilisateurs et leurs statuts.'
+  },
+  {
+    path: 'events',
+    label: 'Événements',
+    requiredPermissions: ['events:read'],
+    description: 'Supervisez les événements publiés sur Meetinity.'
+  },
+  {
+    path: 'moderation',
+    label: 'Modération',
+    requiredPermissions: ['moderation:read'],
+    description: 'Suivez les signalements et prenez des mesures disciplinaires.'
+  },
+  {
+    path: 'reports',
+    label: 'Rapports',
+    requiredPermissions: ['reports:read'],
+    description: 'Analysez les indicateurs clés de la plateforme.'
+  },
+  {
+    path: 'settings',
+    label: 'Paramètres',
+    requiredPermissions: ['settings:read'],
+    description: 'Configurez les paramètres globaux et les intégrations.'
+  }
+]


### PR DESCRIPTION
## Summary
- add a reusable `useWebSocket` hook with reconnection controls for analytics updates
- integrate a D3-based `EventAnalyticsDashboard` and reducer-driven real-time pipeline into event management
- extend the event service plus test suites to cover analytics endpoints and WebSocket-driven state merging

## Testing
- `npx vitest run src/__tests__/eventAnalytics.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d9a67bfa088332874bf92ffe1e0e58