### PR TITLE
Add user analytics dashboard with D3 visualisations

### DIFF
--- a/src/__tests__/userAnalytics.test.tsx
+++ b/src/__tests__/userAnalytics.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react'
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { UserAnalyticsDashboard } from '../components/users/UserAnalyticsDashboard'
+import type {
+  EngagementMetrics,
+  MatchSuccessRate,
+  ActivityHeatmapCell,
+  CohortRetention,
+  GeoDistributionBucket
+} from '../services/userService'
+
+const subscribers = new Set<(event: MessageEvent) => void>()
+let emitWebSocketMessage: (payload: unknown) => void
+
+const fixtures = vi.hoisted(() => ({
+  engagementFixture: {
+    summary: {
+      dailyActiveUsers: 1200,
+      weeklyActiveUsers: 5400,
+      monthlyActiveUsers: 18200,
+      averageSessionDurationMinutes: 24,
+      engagementScore: 4.2
+    },
+    series: [
+      { timestamp: '2024-01-01T00:00:00.000Z', activeUsers: 1000, interactions: 5200, matches: 240 },
+      { timestamp: '2024-01-02T00:00:00.000Z', activeUsers: 1200, interactions: 5800, matches: 265 }
+    ]
+  } as EngagementMetrics,
+  matchFixture: {
+    overallRate: 0.42,
+    segments: [
+      { segment: 'Premium', rate: 0.58 },
+      { segment: 'Standard', rate: 0.37 }
+    ],
+    trend: [
+      { date: '2024-01-01', rate: 0.41 },
+      { date: '2024-01-02', rate: 0.42 }
+    ]
+  } as MatchSuccessRate,
+  heatmapFixture: [
+    { day: 'Lundi', hour: 9, value: 45 },
+    { day: 'Lundi', hour: 10, value: 60 },
+    { day: 'Mardi', hour: 14, value: 80 }
+  ] as ActivityHeatmapCell[],
+  cohortsFixture: [
+    {
+      cohort: 'Janvier 2024',
+      values: [
+        { period: 'Semaine 1', rate: 1 },
+        { period: 'Semaine 2', rate: 0.72 },
+        { period: 'Semaine 3', rate: 0.61 }
+      ]
+    },
+    {
+      cohort: 'Février 2024',
+      values: [
+        { period: 'Semaine 1', rate: 1 },
+        { period: 'Semaine 2', rate: 0.69 }
+      ]
+    }
+  ] as CohortRetention[],
+  geoFixture: [
+    { countryCode: 'FR', countryName: 'France', userCount: 4200 },
+    { countryCode: 'US', countryName: 'États-Unis', userCount: 3100 },
+    { countryCode: 'BR', countryName: 'Brésil', userCount: 900 }
+  ] as GeoDistributionBucket[]
+}))
+
+const onlyDigits = (value: string | null | undefined) => (value ?? '').replace(/\D/g, '')
+const digitsForTestId = (testId: string) => screen.getAllByTestId(testId).map(node => onlyDigits(node.textContent))
+const lastElementByTestId = (testId: string) => {
+  const elements = screen.getAllByTestId(testId)
+  return elements[elements.length - 1]
+}
+
+emitWebSocketMessage = payload => {
+  const message = typeof payload === 'string' ? payload : JSON.stringify(payload)
+  subscribers.forEach(handler => handler({ data: message } as MessageEvent))
+}
+
+vi.mock('../services/userService', () => ({
+  UserService: {
+    getEngagementMetrics: vi.fn().mockResolvedValue(fixtures.engagementFixture),
+    getMatchSuccessRate: vi.fn().mockResolvedValue(fixtures.matchFixture),
+    getActivityHeatmap: vi.fn().mockResolvedValue(fixtures.heatmapFixture),
+    getCohorts: vi.fn().mockResolvedValue(fixtures.cohortsFixture),
+    getGeoDistribution: vi.fn().mockResolvedValue(fixtures.geoFixture)
+  }
+}))
+
+vi.mock('../hooks/useWebSocket', () => ({
+  useWebSocket: () => ({
+    readyState: 1,
+    connectionAttempts: 0,
+    subscribe: (handler: (event: MessageEvent) => void) => {
+      subscribers.add(handler)
+      return () => {
+        subscribers.delete(handler)
+      }
+    },
+    send: vi.fn(),
+    close: vi.fn()
+  })
+}))
+
+describe('User analytics dashboard', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:4000')
+    vi.stubEnv('VITE_WS_BASE_URL', 'ws://localhost:5000/ws')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.clearAllMocks()
+    subscribers.clear()
+  })
+
+  it('renders all analytics widgets with fetched data', async () => {
+    render(<UserAnalyticsDashboard />)
+
+    await waitFor(() => expect(digitsForTestId('engagement-dau')).toContain('1200'))
+
+    expect(screen.getByTestId('match-overall').textContent).toMatch(/42[.,]0/)
+
+    await waitFor(() => {
+      const retentionSvg = lastElementByTestId('retention-chart') as SVGSVGElement
+      expect(retentionSvg.querySelectorAll('path').length).toBeGreaterThan(0)
+    })
+
+    await waitFor(() => {
+      const heatmapSvg = lastElementByTestId('heatmap-chart') as SVGSVGElement
+      expect(heatmapSvg.querySelectorAll('rect').length).toBeGreaterThan(0)
+    })
+
+    await waitFor(() => {
+      const geoSvg = lastElementByTestId('geo-chart') as SVGSVGElement
+      expect(geoSvg.querySelectorAll('path').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('merges realtime engagement and heatmap updates', async () => {
+    render(<UserAnalyticsDashboard />)
+
+    await waitFor(() => expect(digitsForTestId('engagement-dau')).toContain('1200'))
+
+    await act(async () => {
+      emitWebSocketMessage({ type: 'engagement', summary: { dailyActiveUsers: 1500 } })
+    })
+
+    await waitFor(() => expect(digitsForTestId('engagement-dau')).toContain('1500'))
+
+    await act(async () => {
+      emitWebSocketMessage({ type: 'heatmap', day: 'Lundi', hour: 9, value: 99 })
+    })
+
+    await waitFor(() => {
+      const titles = Array.from(lastElementByTestId('heatmap-chart').querySelectorAll('title')).map(
+        node => node.textContent
+      )
+      expect(titles.some(title => title?.includes('99'))).toBe(true)
+    })
+  })
+})

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -7,6 +7,7 @@ import { UserStats } from './UserStats'
 import { useDebounce } from '../hooks/useDebounce'
 import { usePagination } from '../hooks/usePagination'
 import { downloadCsv } from '../utils/csv'
+import { UserAnalyticsDashboard } from './users/UserAnalyticsDashboard'
 
 export function UserManagement() {
   const [users, setUsers] = useState<User[]>([])
@@ -14,6 +15,7 @@ export function UserManagement() {
   const [stats, setStats] = useState({ signups: {}, byIndustry: {}, byStatus: {} })
   const [selected, setSelected] = useState<string[]>([])
   const [selectionResetKey, setSelectionResetKey] = useState(0)
+  const [activeTab, setActiveTab] = useState<'summary' | 'analytics'>('summary')
   const [filters, setFilters] = useState<Filters>({
     search: '',
     status: '',
@@ -129,7 +131,25 @@ export function UserManagement() {
         onSelect={setSelected}
         clearSelectionKey={selectionResetKey}
       />
-      <UserStats stats={stats} />
+      <div className="user-management-tabs">
+        <button
+          type="button"
+          className={activeTab === 'summary' ? 'active' : ''}
+          onClick={() => setActiveTab('summary')}
+          data-testid="user-tab-summary"
+        >
+          Statistiques globales
+        </button>
+        <button
+          type="button"
+          className={activeTab === 'analytics' ? 'active' : ''}
+          onClick={() => setActiveTab('analytics')}
+          data-testid="user-tab-analytics"
+        >
+          Analyse approfondie
+        </button>
+      </div>
+      {activeTab === 'summary' ? <UserStats stats={stats} /> : <UserAnalyticsDashboard />}
     </div>
   )
 }

--- a/src/components/users/UserAnalyticsDashboard.tsx
+++ b/src/components/users/UserAnalyticsDashboard.tsx
@@ -1,0 +1,518 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import * as d3 from 'd3'
+import {
+  UserService,
+  EngagementMetrics,
+  MatchSuccessRate,
+  ActivityHeatmapCell,
+  CohortRetention,
+  GeoDistributionBucket,
+  EngagementMetricPoint
+} from '../../services/userService'
+import { useWebSocket } from '../../hooks/useWebSocket'
+import {
+  aggregateGeoDistribution,
+  buildHeatmapMatrix,
+  buildRetentionSeries,
+  createHeatmapLookup,
+  normaliseEngagement,
+  upsertHeatmapCell,
+  type HeatmapLookup,
+  type RetentionSeries
+} from '../../utils/analytics'
+
+const RETENTION_CHART_SIZE = { width: 640, height: 320 }
+const HEATMAP_CHART_SIZE = { width: 640, height: 360 }
+const MAP_CHART_SIZE = { width: 640, height: 360 }
+
+interface DashboardState {
+  engagement: EngagementMetrics | null
+  matchSuccess: MatchSuccessRate | null
+  heatmap: ActivityHeatmapCell[]
+  cohorts: CohortRetention[]
+  geoDistribution: GeoDistributionBucket[]
+  loading: boolean
+  error: string | null
+}
+
+const INITIAL_STATE: DashboardState = {
+  engagement: null,
+  matchSuccess: null,
+  heatmap: [],
+  cohorts: [],
+  geoDistribution: [],
+  loading: true,
+  error: null
+}
+
+type AnalyticsMessage =
+  | { type: 'engagement'; summary?: Partial<EngagementMetrics['summary']>; point?: EngagementMetricPoint }
+  | { type: 'heatmap'; day: string; hour: number; value: number }
+  | { type: 'unknown'; [key: string]: unknown }
+
+const SIMPLE_WORLD_FEATURES: GeoJSON.FeatureCollection<GeoJSON.Polygon> = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: { region: 'North America' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[-170, 10], [-50, 10], [-50, 75], [-170, 75], [-170, 10]]]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: { region: 'South America' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[-90, -60], [-30, -60], [-30, 15], [-90, 15], [-90, -60]]]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: { region: 'Europe' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[-25, 35], [40, 35], [40, 75], [-25, 75], [-25, 35]]]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: { region: 'Africa' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[-20, -35], [55, -35], [55, 35], [-20, 35], [-20, -35]]]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: { region: 'Middle East' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[35, 10], [65, 10], [65, 35], [35, 35], [35, 10]]]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: { region: 'Asia' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[40, 5], [150, 5], [150, 75], [40, 75], [40, 5]]]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: { region: 'Oceania' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[110, -50], [180, -50], [180, 0], [110, 0], [110, -50]]]
+      }
+    }
+  ]
+}
+
+const CHART_COLORS = d3.schemeTableau10
+
+export function UserAnalyticsDashboard() {
+  const [state, setState] = useState<DashboardState>(INITIAL_STATE)
+  const heatmapLookupRef = useRef<HeatmapLookup>({})
+
+  const retentionChartRef = useRef<SVGSVGElement | null>(null)
+  const heatmapChartRef = useRef<SVGSVGElement | null>(null)
+  const mapChartRef = useRef<SVGSVGElement | null>(null)
+
+  const loadData = useCallback(async () => {
+    setState(prev => ({ ...prev, loading: true, error: null }))
+    try {
+      const [engagement, matchSuccess, heatmap, cohorts, geoDistribution] = await Promise.all([
+        UserService.getEngagementMetrics(),
+        UserService.getMatchSuccessRate(),
+        UserService.getActivityHeatmap(),
+        UserService.getCohorts(),
+        UserService.getGeoDistribution()
+      ])
+
+      heatmapLookupRef.current = createHeatmapLookup(heatmap)
+
+      setState({
+        engagement,
+        matchSuccess,
+        heatmap,
+        cohorts,
+        geoDistribution,
+        loading: false,
+        error: null
+      })
+    } catch (error) {
+      console.error('Failed to load user analytics dashboard data', error)
+      setState(prev => ({ ...prev, loading: false, error: 'Impossible de charger le tableau de bord.' }))
+    }
+  }, [])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  const analyticsSocketUrl = useMemo(() => {
+    const wsBase = (import.meta.env.VITE_WS_BASE_URL as string | undefined)?.replace(/\/$/, '')
+    if (wsBase) {
+      return `${wsBase}/users`
+    }
+    const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '')
+    if (!apiBase) {
+      return null
+    }
+    if (apiBase.startsWith('http')) {
+      return `${apiBase.replace(/^http/, 'ws')}/ws/users`
+    }
+    return `ws://${apiBase}/ws/users`
+  }, [])
+
+  const { subscribe: subscribeToStream } = useWebSocket(analyticsSocketUrl, {
+    enabled: Boolean(analyticsSocketUrl),
+    reconnectInterval: 4000,
+    maxReconnectInterval: 30000
+  })
+
+  useEffect(() => {
+    if (!analyticsSocketUrl) {
+      return undefined
+    }
+
+    return subscribeToStream(event => {
+      try {
+        const parsed = JSON.parse(event.data as string) as AnalyticsMessage
+        if (!parsed || typeof parsed !== 'object' || !('type' in parsed)) {
+          return
+        }
+        switch (parsed.type) {
+          case 'engagement':
+            setState(prev => {
+              if (!prev.engagement) {
+                return prev
+              }
+              const nextSummary = parsed.summary
+                ? { ...prev.engagement.summary, ...parsed.summary }
+                : prev.engagement.summary
+              let nextSeries = prev.engagement.series
+              if (parsed.point) {
+                const existingIndex = nextSeries.findIndex(point => point.timestamp === parsed.point?.timestamp)
+                if (existingIndex >= 0) {
+                  nextSeries = nextSeries.map(point =>
+                    point.timestamp === parsed.point?.timestamp ? { ...point, ...parsed.point } : point
+                  )
+                } else {
+                  nextSeries = [...nextSeries, parsed.point].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+                }
+              }
+              return {
+                ...prev,
+                engagement: {
+                  summary: nextSummary,
+                  series: nextSeries
+                }
+              }
+            })
+            break
+          case 'heatmap':
+            setState(prev => {
+              const update = { day: parsed.day, hour: parsed.hour, value: parsed.value }
+              const nextCells = upsertHeatmapCell(heatmapLookupRef.current, update)
+              heatmapLookupRef.current = createHeatmapLookup(nextCells)
+              return {
+                ...prev,
+                heatmap: nextCells
+              }
+            })
+            break
+          default:
+            break
+        }
+      } catch (error) {
+        console.error('Failed to parse user analytics stream message', error)
+      }
+    })
+  }, [analyticsSocketUrl, subscribeToStream])
+
+  const retentionSeries = useMemo(() => buildRetentionSeries(state.cohorts), [state.cohorts])
+  const heatmapMatrix = useMemo(() => buildHeatmapMatrix(state.heatmap), [state.heatmap])
+  const geoRegions = useMemo(() => aggregateGeoDistribution(state.geoDistribution), [state.geoDistribution])
+  const engagementNormalised = useMemo(() => normaliseEngagement(state.engagement?.series ?? []), [state.engagement])
+
+  useEffect(() => {
+    renderRetentionChart(retentionChartRef.current, retentionSeries)
+  }, [retentionSeries])
+
+  useEffect(() => {
+    renderHeatmapChart(heatmapChartRef.current, heatmapMatrix)
+  }, [heatmapMatrix])
+
+  useEffect(() => {
+    renderChoropleth(mapChartRef.current, geoRegions)
+  }, [geoRegions])
+
+  return (
+    <section className="user-analytics-dashboard">
+      <header className="user-analytics-dashboard__summary">
+        <div>
+          <h2>Engagement des utilisateurs</h2>
+          {state.engagement ? (
+            <div className="user-analytics-dashboard__kpis">
+              <span data-testid="engagement-dau">DAU: {state.engagement.summary.dailyActiveUsers.toLocaleString()}</span>
+              <span data-testid="engagement-wau">WAU: {state.engagement.summary.weeklyActiveUsers.toLocaleString()}</span>
+              <span data-testid="engagement-mau">MAU: {state.engagement.summary.monthlyActiveUsers.toLocaleString()}</span>
+              <span data-testid="engagement-score">
+                Score: {state.engagement.summary.engagementScore.toFixed(1)}
+              </span>
+            </div>
+          ) : (
+            <p data-testid="engagement-loading">Chargement des métriques d'engagement…</p>
+          )}
+        </div>
+        {state.matchSuccess && (
+          <aside className="user-analytics-dashboard__match" data-testid="match-success">
+            <h3>Taux de matching</h3>
+            <p data-testid="match-overall">{(state.matchSuccess.overallRate * 100).toFixed(1)}%</p>
+            <ul>
+              {state.matchSuccess.segments.map(segment => (
+                <li key={segment.segment} data-testid={`match-segment-${segment.segment}`}>
+                  {segment.segment}: {(segment.rate * 100).toFixed(1)}%
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+      </header>
+
+      {state.error && <div className="user-analytics-dashboard__error">{state.error}</div>}
+
+      <div className="user-analytics-dashboard__grid">
+        <article className="user-analytics-dashboard__card" data-testid="retention-card">
+          <header>
+            <h3>Rétention par cohorte</h3>
+          </header>
+          <svg ref={retentionChartRef} data-testid="retention-chart" role="img" aria-label="Graphique de rétention" />
+        </article>
+        <article className="user-analytics-dashboard__card" data-testid="heatmap-card">
+          <header>
+            <h3>Heatmap horaire</h3>
+          </header>
+          <svg ref={heatmapChartRef} data-testid="heatmap-chart" role="img" aria-label="Heatmap d'activité" />
+        </article>
+        <article className="user-analytics-dashboard__card" data-testid="geo-card">
+          <header>
+            <h3>Carte choroplèthe</h3>
+          </header>
+          <svg ref={mapChartRef} data-testid="geo-chart" role="img" aria-label="Carte choroplèthe des utilisateurs" />
+        </article>
+      </div>
+
+      {state.matchSuccess && state.matchSuccess.trend.length > 0 && (
+        <footer className="user-analytics-dashboard__footer">
+          <h4>Tendance du taux de matching</h4>
+          <div className="user-analytics-dashboard__trend" data-testid="match-trend">
+            {state.matchSuccess.trend.map(point => (
+              <span key={point.date}>{point.date}: {(point.rate * 100).toFixed(1)}%</span>
+            ))}
+          </div>
+        </footer>
+      )}
+
+      {engagementNormalised.length > 0 && (
+        <div className="user-analytics-dashboard__sparkline" data-testid="engagement-sparkline">
+          {engagementNormalised.map((value, index) => (
+            <span key={index} style={{ height: `${Math.round(value * 100)}%` }} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function renderRetentionChart(svgElement: SVGSVGElement | null, series: RetentionSeries[]) {
+  if (!svgElement) {
+    return
+  }
+  const svg = d3.select(svgElement)
+  svg.selectAll('*').remove()
+  svg.attr('viewBox', `0 0 ${RETENTION_CHART_SIZE.width} ${RETENTION_CHART_SIZE.height}`)
+
+  if (series.length === 0) {
+    svg
+      .append('text')
+      .attr('x', RETENTION_CHART_SIZE.width / 2)
+      .attr('y', RETENTION_CHART_SIZE.height / 2)
+      .attr('text-anchor', 'middle')
+      .text('Aucune donnée')
+    return
+  }
+
+  const margin = { top: 32, right: 24, bottom: 40, left: 48 }
+  const width = RETENTION_CHART_SIZE.width - margin.left - margin.right
+  const height = RETENTION_CHART_SIZE.height - margin.top - margin.bottom
+  const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+  const flatPoints = series.flatMap(s => s.points)
+  const maxX = d3.max(flatPoints, point => point.periodIndex) ?? 1
+  const x = d3.scaleLinear().domain([0, maxX]).range([0, width])
+  const y = d3.scaleLinear().domain([0, 1]).range([height, 0])
+
+  const xAxis = d3.axisBottom(x).ticks(5).tickFormat(value => `${value}`)
+  const yAxis = d3.axisLeft(y).ticks(5).tickFormat(value => `${Math.round(Number(value) * 100)}%`)
+
+  g.append('g').attr('transform', `translate(0,${height})`).call(xAxis)
+  g.append('g').call(yAxis)
+
+  const line = d3
+    .line<RetentionSeries['points'][number]>()
+    .x(point => x(point.periodIndex))
+    .y(point => y(point.rate))
+    .curve(d3.curveMonotoneX)
+
+  series.forEach((serie, index) => {
+    g.append('path')
+      .datum(serie.points)
+      .attr('fill', 'none')
+      .attr('stroke', CHART_COLORS[index % CHART_COLORS.length])
+      .attr('stroke-width', 2)
+      .attr('d', line)
+  })
+
+  const legend = g
+    .append('g')
+    .attr('transform', `translate(${width - 150},0)`)
+
+  series.forEach((serie, index) => {
+    const row = legend.append('g').attr('transform', `translate(0, ${index * 20})`)
+    row
+      .append('rect')
+      .attr('width', 12)
+      .attr('height', 12)
+      .attr('fill', CHART_COLORS[index % CHART_COLORS.length])
+    row
+      .append('text')
+      .attr('x', 18)
+      .attr('y', 10)
+      .text(serie.cohort)
+  })
+}
+
+function renderHeatmapChart(svgElement: SVGSVGElement | null, matrix: ReturnType<typeof buildHeatmapMatrix>) {
+  if (!svgElement) {
+    return
+  }
+
+  const svg = d3.select(svgElement)
+  svg.selectAll('*').remove()
+  svg.attr('viewBox', `0 0 ${HEATMAP_CHART_SIZE.width} ${HEATMAP_CHART_SIZE.height}`)
+
+  if (matrix.rows.length === 0 || matrix.columns.length === 0) {
+    svg
+      .append('text')
+      .attr('x', HEATMAP_CHART_SIZE.width / 2)
+      .attr('y', HEATMAP_CHART_SIZE.height / 2)
+      .attr('text-anchor', 'middle')
+      .text('Aucune donnée')
+    return
+  }
+
+  const margin = { top: 40, right: 24, bottom: 60, left: 96 }
+  const width = HEATMAP_CHART_SIZE.width - margin.left - margin.right
+  const height = HEATMAP_CHART_SIZE.height - margin.top - margin.bottom
+  const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+  const x = d3.scaleBand<number>().domain(matrix.columns).range([0, width]).padding(0.05)
+  const y = d3.scaleBand<string>().domain(matrix.rows).range([0, height]).padding(0.05)
+  const color = d3
+    .scaleSequential(d3.interpolateYlOrRd)
+    .domain([0, matrix.maxValue === 0 ? 1 : matrix.maxValue])
+
+  matrix.rows.forEach((row, rowIndex) => {
+    matrix.columns.forEach((column, columnIndex) => {
+      const value = matrix.values[rowIndex]?.[columnIndex] ?? 0
+      g.append('rect')
+        .attr('x', x(column) ?? 0)
+        .attr('y', y(row) ?? 0)
+        .attr('width', x.bandwidth())
+        .attr('height', y.bandwidth())
+        .attr('fill', color(value))
+        .append('title')
+        .text(`${row} ${column}h → ${value}`)
+    })
+  })
+
+  const xAxis = d3.axisBottom(x)
+  const yAxis = d3.axisLeft(y)
+
+  g.append('g').attr('transform', `translate(0,${height})`).call(xAxis)
+  g.append('g').call(yAxis)
+}
+
+function renderChoropleth(svgElement: SVGSVGElement | null, data: ReturnType<typeof aggregateGeoDistribution>) {
+  if (!svgElement) {
+    return
+  }
+
+  const svg = d3.select(svgElement)
+  svg.selectAll('*').remove()
+  svg.attr('viewBox', `0 0 ${MAP_CHART_SIZE.width} ${MAP_CHART_SIZE.height}`)
+
+  const projection = d3
+    .geoMercator()
+    .fitSize([MAP_CHART_SIZE.width - 40, MAP_CHART_SIZE.height - 40], SIMPLE_WORLD_FEATURES)
+  const path = d3.geoPath(projection)
+
+  const maxValue = d3.max(data, d => d.value) ?? 0
+  const color = d3.scaleSequential(d3.interpolateBlues).domain([0, maxValue === 0 ? 1 : maxValue])
+
+  const g = svg.append('g').attr('transform', 'translate(20,20)')
+
+  g.selectAll('path')
+    .data(SIMPLE_WORLD_FEATURES.features)
+    .enter()
+    .append('path')
+    .attr('d', path as any)
+    .attr('stroke', '#1f2937')
+    .attr('stroke-width', 0.5)
+    .attr('fill', feature => {
+      const region = feature.properties?.region as string
+      const datum = data.find(entry => entry.id === region)
+      return color(datum?.value ?? 0)
+    })
+    .append('title')
+    .text(feature => {
+      const region = feature.properties?.region as string
+      const datum = data.find(entry => entry.id === region)
+      return `${region}: ${datum?.value ?? 0}`
+    })
+
+  const legendWidth = 200
+  const legendHeight = 12
+  const legendMargin = { top: MAP_CHART_SIZE.height - 40, left: MAP_CHART_SIZE.width - legendWidth - 40 }
+
+  const legend = svg.append('g').attr('transform', `translate(${legendMargin.left}, ${legendMargin.top})`)
+
+  const gradientId = 'user-analytics-map-gradient'
+  const defs = svg.append('defs')
+  const gradient = defs.append('linearGradient').attr('id', gradientId)
+  gradient.attr('x1', '0%').attr('x2', '100%').attr('y1', '0%').attr('y2', '0%')
+  gradient
+    .selectAll('stop')
+    .data([0, 1])
+    .enter()
+    .append('stop')
+    .attr('offset', d => `${d * 100}%`)
+    .attr('stop-color', d => color(d * maxValue))
+
+  legend
+    .append('rect')
+    .attr('width', legendWidth)
+    .attr('height', legendHeight)
+    .attr('fill', `url(#${gradientId})`)
+
+  const legendScale = d3.scaleLinear().domain([0, maxValue]).range([0, legendWidth])
+  const legendAxis = d3.axisBottom(legendScale).ticks(4)
+
+  legend.append('g').attr('transform', `translate(0, ${legendHeight})`).call(legendAxis)
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -27,6 +27,66 @@ export interface Stats {
   byStatus: Record<string, number>
 }
 
+export interface EngagementMetricPoint {
+  timestamp: string
+  activeUsers: number
+  interactions: number
+  matches: number
+}
+
+export interface EngagementMetricsSummary {
+  dailyActiveUsers: number
+  weeklyActiveUsers: number
+  monthlyActiveUsers: number
+  averageSessionDurationMinutes: number
+  engagementScore: number
+}
+
+export interface EngagementMetrics {
+  summary: EngagementMetricsSummary
+  series: EngagementMetricPoint[]
+}
+
+export interface MatchSuccessRateSegment {
+  segment: string
+  rate: number
+}
+
+export interface MatchSuccessRateTrendPoint {
+  date: string
+  rate: number
+}
+
+export interface MatchSuccessRate {
+  overallRate: number
+  segments: MatchSuccessRateSegment[]
+  trend: MatchSuccessRateTrendPoint[]
+}
+
+export interface ActivityHeatmapCell {
+  day: string
+  hour: number
+  value: number
+}
+
+export interface CohortRetentionPoint {
+  period: string
+  rate: number
+}
+
+export interface CohortRetention {
+  cohort: string
+  values: CohortRetentionPoint[]
+}
+
+export interface GeoDistributionBucket {
+  countryCode: string
+  countryName: string
+  userCount: number
+  latitude?: number
+  longitude?: number
+}
+
 export const UserService = {
   async list(params: ListParams) {
     const { data } = await axios.get(`${API}/api/users`, { params })
@@ -45,6 +105,26 @@ export const UserService = {
   async stats() {
     const { data } = await axios.get(`${API}/api/users/stats`)
     return data as Stats
+  },
+  async getEngagementMetrics() {
+    const { data } = await axios.get(`${API}/api/users/engagement`)
+    return data as EngagementMetrics
+  },
+  async getMatchSuccessRate() {
+    const { data } = await axios.get(`${API}/api/users/match-success`)
+    return data as MatchSuccessRate
+  },
+  async getActivityHeatmap() {
+    const { data } = await axios.get(`${API}/api/users/activity-heatmap`)
+    return data as ActivityHeatmapCell[]
+  },
+  async getCohorts() {
+    const { data } = await axios.get(`${API}/api/users/cohorts`)
+    return data as CohortRetention[]
+  },
+  async getGeoDistribution() {
+    const { data } = await axios.get(`${API}/api/users/geo-distribution`)
+    return data as GeoDistributionBucket[]
   },
   async export(params: ListParams) {
     const res = await axios.get(`${API}/api/users/export`, {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,276 @@
+import type {
+  ActivityHeatmapCell,
+  CohortRetention,
+  CohortRetentionPoint,
+  EngagementMetricPoint,
+  GeoDistributionBucket
+} from '../services/userService'
+
+/**
+ * Normalised representation of a cohort retention curve that D3 can consume.
+ */
+export interface RetentionSeriesPoint {
+  periodIndex: number
+  periodLabel: string
+  rate: number
+}
+
+export interface RetentionSeries {
+  cohort: string
+  points: RetentionSeriesPoint[]
+}
+
+/**
+ * Computes cohort based retention series with a deterministic period order so that
+ * D3 line charts can easily render retention curves across cohorts.
+ */
+export function buildRetentionSeries(cohorts: CohortRetention[]): RetentionSeries[] {
+  return cohorts.map(cohort => {
+    const indexedPoints = cohort.values
+      .map((value, index) => ({ index, derivedIndex: derivePeriodIndex(value, index), value }))
+      .sort((a, b) => a.derivedIndex - b.derivedIndex)
+      .map(({ value, derivedIndex }) => ({
+        periodIndex: derivedIndex,
+        periodLabel: value.period,
+        rate: clampRate(value.rate)
+      }))
+
+    return {
+      cohort: cohort.cohort,
+      points: indexedPoints
+    }
+  })
+}
+
+const PERIOD_MATCHER = /(\d+(?:[.,]\d+)?)/
+
+function derivePeriodIndex(point: CohortRetentionPoint, fallbackIndex: number): number {
+  const match = point.period.match(PERIOD_MATCHER)
+  if (!match) {
+    return fallbackIndex
+  }
+  const numeric = Number(match[1].replace(',', '.'))
+  if (Number.isFinite(numeric)) {
+    return numeric
+  }
+  return fallbackIndex
+}
+
+function clampRate(rate: number): number {
+  if (Number.isNaN(rate)) {
+    return 0
+  }
+  if (rate < 0) {
+    return 0
+  }
+  if (rate > 1 && rate <= 100) {
+    return rate / 100
+  }
+  if (rate > 1) {
+    return 1
+  }
+  return rate
+}
+
+export interface HeatmapMatrix {
+  rows: string[]
+  columns: number[]
+  values: number[][]
+  maxValue: number
+}
+
+const DAY_ORDER = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+  'lundi',
+  'mardi',
+  'mercredi',
+  'jeudi',
+  'vendredi',
+  'samedi',
+  'dimanche'
+]
+
+function resolveDayIndex(day: string, fallbackIndex: number): number {
+  const idx = DAY_ORDER.indexOf(day.toLowerCase())
+  return idx === -1 ? fallbackIndex : idx
+}
+
+/**
+ * Builds a two-dimensional matrix describing activity intensity so we can paint
+ * a D3 heatmap without recomputing lookups in render loops.
+ */
+export function buildHeatmapMatrix(cells: ActivityHeatmapCell[]): HeatmapMatrix {
+  const rows: string[] = []
+  const rowIndex = new Map<string, number>()
+  const columnsSet = new Set<number>()
+  let maxValue = 0
+
+  const sortedCells = [...cells].sort((a, b) => {
+    const dayDiff =
+      resolveDayIndex(a.day, Number.MAX_SAFE_INTEGER) - resolveDayIndex(b.day, Number.MAX_SAFE_INTEGER)
+    if (dayDiff !== 0) {
+      return dayDiff
+    }
+    return a.hour - b.hour
+  })
+
+  sortedCells.forEach(cell => {
+    if (!rowIndex.has(cell.day)) {
+      rowIndex.set(cell.day, rows.length)
+      rows.push(cell.day)
+    }
+    columnsSet.add(cell.hour)
+  })
+
+  const columns = Array.from(columnsSet).sort((a, b) => a - b)
+  const columnIndex = new Map(columns.map((hour, index) => [hour, index]))
+  const values = rows.map(() => columns.map(() => 0))
+
+  sortedCells.forEach(cell => {
+    const r = rowIndex.get(cell.day)
+    const c = columnIndex.get(cell.hour)
+    if (typeof r === 'number' && typeof c === 'number') {
+      values[r][c] = cell.value
+      if (cell.value > maxValue) {
+        maxValue = cell.value
+      }
+    }
+  })
+
+  return {
+    rows,
+    columns,
+    values,
+    maxValue
+  }
+}
+
+export interface ChoroplethRegionDatum {
+  id: string
+  label: string
+  value: number
+}
+
+const COUNTRY_REGION_MAP: Record<string, string> = {
+  US: 'North America',
+  CA: 'North America',
+  MX: 'North America',
+  BR: 'South America',
+  AR: 'South America',
+  CL: 'South America',
+  GB: 'Europe',
+  FR: 'Europe',
+  DE: 'Europe',
+  ES: 'Europe',
+  IT: 'Europe',
+  PT: 'Europe',
+  NL: 'Europe',
+  BE: 'Europe',
+  PL: 'Europe',
+  SE: 'Europe',
+  NO: 'Europe',
+  DK: 'Europe',
+  FI: 'Europe',
+  IE: 'Europe',
+  CH: 'Europe',
+  AT: 'Europe',
+  CN: 'Asia',
+  JP: 'Asia',
+  KR: 'Asia',
+  SG: 'Asia',
+  IN: 'Asia',
+  ID: 'Asia',
+  TH: 'Asia',
+  PH: 'Asia',
+  AE: 'Middle East',
+  SA: 'Middle East',
+  QA: 'Middle East',
+  ZA: 'Africa',
+  NG: 'Africa',
+  EG: 'Africa',
+  KE: 'Africa',
+  MA: 'Africa',
+  TN: 'Africa',
+  AU: 'Oceania',
+  NZ: 'Oceania'
+}
+
+const REGION_LABELS = [
+  'North America',
+  'South America',
+  'Europe',
+  'Africa',
+  'Middle East',
+  'Asia',
+  'Oceania',
+  'Other'
+]
+
+/**
+ * Aggregates country level distribution into wider geographic buckets in order to
+ * render a simplified choropleth representation without shipping a large GeoJSON dataset.
+ */
+export function aggregateGeoDistribution(buckets: GeoDistributionBucket[]): ChoroplethRegionDatum[] {
+  const totals = new Map<string, number>()
+
+  buckets.forEach(bucket => {
+    const region = COUNTRY_REGION_MAP[bucket.countryCode.toUpperCase()] ?? 'Other'
+    const previous = totals.get(region) ?? 0
+    totals.set(region, previous + bucket.userCount)
+  })
+
+  return REGION_LABELS.map(region => ({
+    id: region,
+    label: region,
+    value: totals.get(region) ?? 0
+  }))
+}
+
+/**
+ * Projects engagement activity into a single normalised range so that radial gauges or
+ * summary visuals can be created without duplicating code in React components.
+ */
+export function normaliseEngagement(series: EngagementMetricPoint[]): number[] {
+  const max = series.reduce((acc, point) => Math.max(acc, point.activeUsers), 0)
+  if (max === 0) {
+    return series.map(() => 0)
+  }
+  return series.map(point => point.activeUsers / max)
+}
+
+export type HeatmapLookup = Record<string, Record<number, ActivityHeatmapCell>>
+
+/**
+ * Creates an indexable structure for heatmap cells keyed by day/hour, used when
+ * merging realtime WebSocket updates.
+ */
+export function createHeatmapLookup(cells: ActivityHeatmapCell[]): HeatmapLookup {
+  return cells.reduce<HeatmapLookup>((acc, cell) => {
+    if (!acc[cell.day]) {
+      acc[cell.day] = {}
+    }
+    acc[cell.day][cell.hour] = cell
+    return acc
+  }, {})
+}
+
+/**
+ * Applies a single cell update to an existing lookup, returning a brand new array
+ * representation that can easily be fed back into D3 data joins.
+ */
+export function upsertHeatmapCell(lookup: HeatmapLookup, update: ActivityHeatmapCell): ActivityHeatmapCell[] {
+  const next: HeatmapLookup = { ...lookup, [update.day]: { ...(lookup[update.day] ?? {}) } }
+  next[update.day][update.hour] = update
+
+  const rows = Object.entries(next)
+    .sort((a, b) => resolveDayIndex(a[0], Number.MAX_SAFE_INTEGER) - resolveDayIndex(b[0], Number.MAX_SAFE_INTEGER))
+    .map(([, hours]) => Object.values(hours))
+
+  return rows.flat()
+}


### PR DESCRIPTION
## Summary
- extend the user service with engagement, heatmap, cohort, match-rate and geo distribution endpoints and typings
- add reusable analytics utilities plus a D3-powered `UserAnalyticsDashboard` that subscribes to websocket updates
- integrate the dashboard into user management via tabs and add tests covering realtime behaviour and chart rendering

## Testing
- npx vitest run src/__tests__/userAnalytics.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9b138a89c83329b341dbf372ce421