### PR TITLE
Add moderation dashboard workflow

### DIFF
--- a/src/__tests__/moderation.test.tsx
+++ b/src/__tests__/moderation.test.tsx
@@ -1,0 +1,215 @@
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import * as matchers from '@testing-library/jest-dom/matchers'
+import React from 'react'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from '../app'
+import { AuthService } from '../services/authService'
+import { ModerationService } from '../services/moderationService'
+
+vi.mock('../services/authService', () => ({
+  AuthService: {
+    getSession: vi.fn(),
+    getPermissions: vi.fn()
+  }
+}))
+
+vi.mock('../services/moderationService', () => {
+  const service = {
+    listReports: vi.fn(),
+    getReport: vi.fn(),
+    submitDecision: vi.fn(),
+    assignReport: vi.fn(),
+    getRules: vi.fn(),
+    createRule: vi.fn(),
+    updateRule: vi.fn(),
+    toggleRule: vi.fn(),
+    reorderRules: vi.fn(),
+    deleteRule: vi.fn(),
+    getAuditTrail: vi.fn(),
+    exportAuditTrail: vi.fn(),
+    listAppeals: vi.fn(),
+    updateAppeal: vi.fn()
+  }
+
+  return {
+    ModerationService: service,
+    MODERATION_STATUS_LABELS: {
+      pending: 'En attente',
+      under_review: 'En cours',
+      action_taken: 'Action effectuée',
+      dismissed: 'Rejeté',
+      escalated: 'Escaladé'
+    }
+  }
+})
+
+vi.mock('../utils/csv', () => ({
+  downloadCsv: vi.fn()
+}))
+
+expect.extend(matchers)
+
+const mockedAuthService = vi.mocked(AuthService, true)
+const mockedModerationService = vi.mocked(ModerationService, true)
+
+describe('Moderation dashboard', () => {
+  const now = new Date().toISOString()
+  const report = {
+    id: 'rep-1',
+    contentId: 'post-001',
+    contentType: 'post',
+    snippet: 'Contenu signalé à examiner',
+    reporterId: 'usr-2',
+    reporterName: 'Alice',
+    reason: 'Discours haineux',
+    status: 'pending',
+    severity: 'high',
+    assignedTo: 'moderator-1',
+    evidenceUrls: ['https://example.com/evidence'],
+    createdAt: now
+  }
+  const updatedReport = { ...report, status: 'action_taken' as const }
+  const rules = [
+    {
+      id: 'rule-1',
+      name: 'Filtrer les injures',
+      description: 'Supprime automatiquement les contenus injurieux',
+      enabled: true,
+      priority: 1,
+      severity: 'high' as const,
+      conditions: {},
+      actions: {},
+      lastTriggeredAt: now
+    }
+  ]
+  const appeals = [
+    {
+      id: 'appeal-1',
+      reportId: report.id,
+      userId: 'usr-3',
+      userName: 'Bob',
+      submittedAt: now,
+      status: 'pending' as const,
+      notes: 'Je n’ai rien fait de mal'
+    }
+  ]
+  const auditEntries = [
+    {
+      id: 'audit-1',
+      timestamp: now,
+      actor: 'moderator-1',
+      action: 'Consultation du rapport',
+      targetId: report.id,
+      targetType: 'report',
+      status: 'pending' as const
+    }
+  ]
+
+  let originalCreateObjectURL: typeof URL.createObjectURL | undefined
+  let originalRevokeObjectURL: typeof URL.revokeObjectURL | undefined
+
+  beforeAll(() => {
+    originalCreateObjectURL = URL.createObjectURL
+    originalRevokeObjectURL = URL.revokeObjectURL
+
+    URL.createObjectURL = vi.fn(() => 'blob:mock')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterAll(() => {
+    if (originalCreateObjectURL) {
+      URL.createObjectURL = originalCreateObjectURL
+    } else {
+      delete (URL as unknown as { createObjectURL?: typeof URL.createObjectURL }).createObjectURL
+    }
+
+    if (originalRevokeObjectURL) {
+      URL.revokeObjectURL = originalRevokeObjectURL
+    } else {
+      delete (URL as unknown as { revokeObjectURL?: typeof URL.revokeObjectURL }).revokeObjectURL
+    }
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.pushState({}, '', '/admin/moderation')
+
+    mockedAuthService.getSession.mockResolvedValue({
+      id: 'admin-1',
+      email: 'admin@example.com',
+      name: 'Admin',
+      role: 'super-admin'
+    })
+
+    mockedAuthService.getPermissions.mockResolvedValue({
+      permissions: ['admin:access', 'moderation:read', 'moderation:write'],
+      roles: ['super-admin']
+    })
+
+    mockedModerationService.listReports.mockResolvedValue({ reports: [report], total: 1 })
+    mockedModerationService.getAuditTrail.mockResolvedValue({ entries: auditEntries, total: 1 })
+    mockedModerationService.getRules.mockResolvedValue(rules)
+    mockedModerationService.toggleRule.mockImplementation(async (_, enabled) => ({
+      ...rules[0],
+      enabled
+    }))
+    mockedModerationService.reorderRules.mockResolvedValue(rules)
+    mockedModerationService.listAppeals.mockResolvedValue({ appeals, total: 1 })
+    mockedModerationService.updateAppeal.mockImplementation(async (id, payload) => ({
+      ...appeals[0],
+      id,
+      status: payload.status
+    }))
+    mockedModerationService.submitDecision.mockResolvedValue(updatedReport)
+    mockedModerationService.exportAuditTrail.mockResolvedValue(new Blob())
+  })
+
+  it('navigates to moderation module and loads reported content', async () => {
+    render(<App />)
+
+    await waitFor(() => expect(mockedModerationService.listReports).toHaveBeenCalled())
+
+    expect(screen.getByText('Signalements')).toBeInTheDocument()
+    expect(screen.getByText(report.snippet)).toBeInTheDocument()
+    expect(screen.getByTestId('appeals-queue')).toBeInTheDocument()
+  })
+
+  it('requires a comment before submitting a decision and propagates actions', async () => {
+    render(<App />)
+
+    const table = await screen.findByTestId('reported-content-table')
+    const firstRow = within(table).getByTestId(`report-row-${report.id}`)
+    fireEvent.click(firstRow)
+
+    const submitButton = await screen.findByTestId('moderation-submit')
+    expect(submitButton).toBeDisabled()
+
+    const commentArea = screen.getByTestId('moderation-comment') as HTMLTextAreaElement
+    fireEvent.change(commentArea, { target: { value: 'Contenu supprimé après vérification.' } })
+    expect(submitButton).not.toBeDisabled()
+
+    fireEvent.click(submitButton)
+
+    await waitFor(() => expect(mockedModerationService.submitDecision).toHaveBeenCalledWith(report.id, {
+      action: 'remove',
+      comment: 'Contenu supprimé après vérification.',
+      escalate: false
+    }))
+
+    await waitFor(() => expect(mockedModerationService.getAuditTrail).toHaveBeenCalledTimes(2))
+
+    const [toggle] = await screen.findAllByTestId(`rule-toggle-${rules[0].id}`)
+    fireEvent.click(toggle)
+    await waitFor(() => expect(mockedModerationService.toggleRule).toHaveBeenCalledWith(rules[0].id, false))
+
+    const [approveButton] = await screen.findAllByTestId(`appeal-approve-${appeals[0].id}`)
+    fireEvent.click(approveButton)
+    await waitFor(() => expect(mockedModerationService.updateAppeal).toHaveBeenCalledWith(appeals[0].id, {
+      status: 'approved'
+    }))
+
+    const [exportJsonButton] = await screen.findAllByTestId('audit-export-json')
+    fireEvent.click(exportJsonButton)
+    await waitFor(() => expect(mockedModerationService.exportAuditTrail).toHaveBeenCalledWith('json', expect.any(Object)))
+  })
+})

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,6 +5,7 @@ import { EventManagement } from './components/events/EventManagement'
 import { AuthProvider, usePermissions } from './hooks/usePermissions'
 import { AdminLayout } from './components/layout/AdminLayout'
 import { ADMIN_MODULES } from './utils/adminNavigation'
+import { ModerationDashboard } from './components/moderation/ModerationDashboard'
 
 interface RequirePermissionsProps {
   requiredPermissions?: string[]
@@ -90,6 +91,8 @@ export default function App() {
                       <UserManagement />
                     ) : module.path === 'events' ? (
                       <EventManagement />
+                    ) : module.path === 'moderation' ? (
+                      <ModerationDashboard />
                     ) : (
                       <ModulePlaceholder title={module.label} description={module.description} />
                     )}

--- a/src/components/moderation/AppealsQueue.tsx
+++ b/src/components/moderation/AppealsQueue.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ModerationAppeal,
+  ModerationFilters,
+  ModerationService
+} from '../../services/moderationService'
+
+interface AppealsQueueProps {
+  filters: ModerationFilters
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onDecision?: () => void
+}
+
+export function AppealsQueue({ filters, page, pageSize, onPageChange, onDecision }: AppealsQueueProps) {
+  const [appeals, setAppeals] = useState<ModerationAppeal[]>([])
+  const [total, setTotal] = useState(0)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isUpdating, setIsUpdating] = useState(false)
+  const requestId = useRef(0)
+
+  const normalizedFilters = useMemo(() => ({
+    ...filters,
+    severity: filters.severity === 'all' ? undefined : filters.severity,
+    contentType: filters.contentType === 'all' ? undefined : filters.contentType,
+    ruleId: filters.ruleId || undefined
+  }), [filters])
+
+  useEffect(() => {
+    let isMounted = true
+    const currentRequest = requestId.current + 1
+    requestId.current = currentRequest
+
+    const fetchAppeals = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const { appeals: data, total: count } = await ModerationService.listAppeals({
+          ...normalizedFilters,
+          page,
+          pageSize
+        })
+
+        if (!isMounted || currentRequest !== requestId.current) {
+          return
+        }
+
+        setAppeals(data)
+        setTotal(count)
+
+        if (data.length === 0 && page > 0) {
+          onPageChange(Math.max(0, page - 1))
+        }
+      } catch (err) {
+        console.error('Failed to load appeals', err)
+        if (isMounted) {
+          setError('Impossible de charger la file des appels.')
+        }
+      } finally {
+        if (isMounted && currentRequest === requestId.current) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchAppeals()
+
+    return () => {
+      isMounted = false
+    }
+  }, [normalizedFilters, onPageChange, page, pageSize])
+
+  const handleUpdate = async (appeal: ModerationAppeal, status: ModerationAppeal['status']) => {
+    setIsUpdating(true)
+    setError(null)
+
+    try {
+      const updated = await ModerationService.updateAppeal(appeal.id, { status })
+      setAppeals(prev => prev.map(item => (item.id === updated.id ? updated : item)))
+      onDecision?.()
+    } catch (err) {
+      console.error('Failed to update appeal', err)
+      setError("La mise à jour de l'appel a échoué.")
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  const totalPages = total > 0 ? Math.ceil(total / pageSize) : 0
+
+  return (
+    <div className="moderation-appeals" data-testid="appeals-queue">
+      <header className="moderation-appeals__header">
+        <h3>Appels</h3>
+        {isUpdating && <span>Traitement…</span>}
+      </header>
+      {isLoading && <p>Chargement des appels…</p>}
+      {error && <p className="moderation-dashboard__error">{error}</p>}
+      {!isLoading && !error && appeals.length === 0 && <p>Aucun appel en attente.</p>}
+      <ul className="moderation-appeals__list">
+        {appeals.map(appeal => (
+          <li key={appeal.id} className={`moderation-appeals__item moderation-appeals__item--${appeal.status}`}>
+            <div className="moderation-appeals__summary">
+              <strong>{appeal.userName || appeal.userId}</strong>
+              <span>Rapport #{appeal.reportId}</span>
+              <span>Soumis le {new Date(appeal.submittedAt).toLocaleString()}</span>
+            </div>
+            <div className="moderation-appeals__actions">
+              <button
+                type="button"
+                onClick={() => handleUpdate(appeal, 'approved')}
+                disabled={isUpdating}
+                data-testid={`appeal-approve-${appeal.id}`}
+              >
+                Approuver
+              </button>
+              <button
+                type="button"
+                onClick={() => handleUpdate(appeal, 'rejected')}
+                disabled={isUpdating}
+                data-testid={`appeal-reject-${appeal.id}`}
+              >
+                Rejeter
+              </button>
+            </div>
+            {appeal.notes && <p className="moderation-appeals__notes">{appeal.notes}</p>}
+          </li>
+        ))}
+      </ul>
+      <footer className="moderation-appeals__pagination">
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.max(0, page - 1))}
+          disabled={isLoading || page === 0}
+        >
+          Précédent
+        </button>
+        <span>
+          Page {totalPages === 0 ? 0 : page + 1} / {totalPages}
+        </span>
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={isLoading || totalPages === 0 || page + 1 >= totalPages}
+        >
+          Suivant
+        </button>
+      </footer>
+    </div>
+  )
+}

--- a/src/components/moderation/ModerationDashboard.tsx
+++ b/src/components/moderation/ModerationDashboard.tsx
@@ -1,0 +1,263 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AuditTrailEntry,
+  ModerationFilters,
+  ModerationService,
+  ModerationStatus,
+  MODERATION_STATUS_LABELS,
+  ReportedContent
+} from '../../services/moderationService'
+import { usePagination } from '../../hooks/usePagination'
+import { useDebounce } from '../../hooks/useDebounce'
+import { ReportedContentTable } from './ReportedContentTable'
+import { UserModerationPanel } from './UserModerationPanel'
+import { ModerationRulesEditor } from './ModerationRulesEditor'
+import { AppealsQueue } from './AppealsQueue'
+import { downloadCsv } from '../../utils/csv'
+
+const STATUS_LABELS: Record<ModerationStatus | 'all', string> = {
+  all: 'Tous les statuts',
+  ...MODERATION_STATUS_LABELS
+}
+
+const severityOptions = [
+  { value: 'all', label: 'Toutes les sévérités' },
+  { value: 'low', label: 'Faible' },
+  { value: 'medium', label: 'Modérée' },
+  { value: 'high', label: 'Critique' }
+]
+
+const contentTypes = [
+  { value: 'all', label: 'Tous les contenus' },
+  { value: 'message', label: 'Messages' },
+  { value: 'post', label: 'Publications' },
+  { value: 'profile', label: 'Profils' }
+]
+
+interface DashboardFilters extends ModerationFilters {
+  search: string
+  status: ModerationStatus | 'all'
+  severity: 'low' | 'medium' | 'high' | 'all'
+  contentType: string
+}
+
+const defaultFilters: DashboardFilters = {
+  search: '',
+  status: 'pending',
+  severity: 'all',
+  contentType: 'all'
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+export function ModerationDashboard() {
+  const [filters, setFilters] = useState<DashboardFilters>(defaultFilters)
+  const [selectedReport, setSelectedReport] = useState<ReportedContent | null>(null)
+  const [auditTrail, setAuditTrail] = useState<AuditTrailEntry[]>([])
+  const [auditTotal, setAuditTotal] = useState(0)
+  const [auditError, setAuditError] = useState<string | null>(null)
+  const [isAuditLoading, setIsAuditLoading] = useState(false)
+
+  const { page, pageSize, setPage } = usePagination(20)
+  const debouncedSearch = useDebounce(filters.search, 250)
+
+  const normalizedFilters = useMemo<ModerationFilters>(
+    () => ({
+      ...filters,
+      search: debouncedSearch
+    }),
+    [filters, debouncedSearch]
+  )
+
+  const loadAuditTrail = useCallback(async () => {
+    setIsAuditLoading(true)
+    setAuditError(null)
+
+    try {
+      const { entries, total } = await ModerationService.getAuditTrail({
+        ...normalizedFilters,
+        page,
+        pageSize
+      })
+      setAuditTrail(entries)
+      setAuditTotal(total)
+    } catch (error) {
+      console.error('Failed to load audit trail', error)
+      setAuditError("Impossible de charger l'historique des décisions.")
+    } finally {
+      setIsAuditLoading(false)
+    }
+  }, [normalizedFilters, page, pageSize])
+
+  useEffect(() => {
+    loadAuditTrail()
+  }, [loadAuditTrail])
+
+  const handleFilterChange = (changes: Partial<DashboardFilters>) => {
+    setFilters(prev => ({ ...prev, ...changes }))
+    setPage(0)
+  }
+
+  const handleReportSelection = (report: ReportedContent | null) => {
+    setSelectedReport(report)
+  }
+
+  const handleDecisionComplete = (updated: ReportedContent) => {
+    setSelectedReport(updated)
+    loadAuditTrail()
+  }
+
+  const handleAuditExport = async (format: 'json' | 'csv') => {
+    try {
+      const blob = await ModerationService.exportAuditTrail(format, {
+        ...normalizedFilters,
+        page,
+        pageSize
+      })
+
+      if (format === 'csv') {
+        downloadCsv(blob, `audit-trail.${format}`)
+      } else {
+        downloadBlob(blob, `audit-trail.${format}`)
+      }
+    } catch (error) {
+      console.error('Failed to export audit trail', error)
+      setAuditError("L'export de l'historique a échoué. Réessayez ultérieurement.")
+    }
+  }
+
+  return (
+    <div className="moderation-dashboard">
+      <header className="moderation-dashboard__header">
+        <div>
+          <h2>Centre de modération</h2>
+          <p>Inspectez les signalements, appliquez des décisions et ajustez les règles automatiques.</p>
+        </div>
+        <div className="moderation-dashboard__export">
+          <button type="button" onClick={() => handleAuditExport('json')} data-testid="audit-export-json">
+            Export JSON
+          </button>
+          <button type="button" onClick={() => handleAuditExport('csv')} data-testid="audit-export-csv">
+            Export CSV
+          </button>
+        </div>
+      </header>
+
+      <section className="moderation-dashboard__filters">
+        <input
+          type="search"
+          placeholder="Rechercher un contenu, un utilisateur ou une règle"
+          value={filters.search}
+          onChange={event => handleFilterChange({ search: event.target.value })}
+          aria-label="Recherche de signalements"
+        />
+        <select
+          value={filters.status}
+          onChange={event => handleFilterChange({ status: event.target.value as DashboardFilters['status'] })}
+          aria-label="Filtrer par statut"
+        >
+          {Object.entries(STATUS_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={filters.severity}
+          onChange={event => handleFilterChange({ severity: event.target.value as DashboardFilters['severity'] })}
+          aria-label="Filtrer par sévérité"
+        >
+          {severityOptions.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={filters.contentType}
+          onChange={event => handleFilterChange({ contentType: event.target.value })}
+          aria-label="Filtrer par type de contenu"
+        >
+          {contentTypes.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <button type="button" onClick={() => handleFilterChange(defaultFilters)}>
+          Réinitialiser
+        </button>
+      </section>
+
+      <section className="moderation-dashboard__main">
+        <div className="moderation-dashboard__reports">
+          <ReportedContentTable
+            filters={normalizedFilters}
+            page={page}
+            pageSize={pageSize}
+            onPageChange={setPage}
+            onSelectReport={handleReportSelection}
+            selectedReportId={selectedReport?.id}
+          />
+        </div>
+        <aside className="moderation-dashboard__panel">
+          <UserModerationPanel
+            report={selectedReport}
+            onDecisionComplete={handleDecisionComplete}
+            filters={normalizedFilters}
+          />
+        </aside>
+      </section>
+
+      <section className="moderation-dashboard__secondary">
+        <ModerationRulesEditor filters={normalizedFilters} onRulesUpdated={loadAuditTrail} />
+        <AppealsQueue
+          filters={normalizedFilters}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onDecision={loadAuditTrail}
+        />
+      </section>
+
+      <section className="moderation-dashboard__audit" aria-live="polite">
+        <header className="moderation-dashboard__audit-header">
+          <h3>Historique des décisions</h3>
+          <span>
+            {auditTotal} entrée{auditTotal > 1 ? 's' : ''}
+          </span>
+        </header>
+        {isAuditLoading && <p>Chargement de l'historique…</p>}
+        {auditError && <p className="moderation-dashboard__error">{auditError}</p>}
+        {!isAuditLoading && !auditError && auditTrail.length === 0 && (
+          <p>Aucune action enregistrée pour les filtres actuels.</p>
+        )}
+        <ul className="moderation-dashboard__audit-list">
+          {auditTrail.map(entry => (
+            <li key={entry.id} className="moderation-dashboard__audit-item">
+              <div>
+                <strong>{entry.action}</strong>
+                <div className="moderation-dashboard__audit-meta">
+                  <span>Par {entry.actor}</span>
+                  <span>{new Date(entry.timestamp).toLocaleString()}</span>
+                </div>
+              </div>
+              <div className="moderation-dashboard__audit-target">
+                <span>Sur {entry.targetType}</span>
+                <span>ID : {entry.targetId}</span>
+                {entry.status && <span>Statut : {STATUS_LABELS[entry.status]}</span>}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/components/moderation/ModerationRulesEditor.tsx
+++ b/src/components/moderation/ModerationRulesEditor.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  ModerationFilters,
+  ModerationRule,
+  ModerationService
+} from '../../services/moderationService'
+
+interface ModerationRulesEditorProps {
+  filters: ModerationFilters
+  onRulesUpdated?: () => void
+}
+
+export function ModerationRulesEditor({ filters, onRulesUpdated }: ModerationRulesEditorProps) {
+  const [rules, setRules] = useState<ModerationRule[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const normalizedFilters = useMemo(() => ({
+    ...filters,
+    status: undefined,
+    severity: filters.severity === 'all' ? undefined : filters.severity,
+    contentType: filters.contentType === 'all' ? undefined : filters.contentType,
+    ruleId: filters.ruleId || undefined
+  }), [filters])
+
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchRules = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const data = await ModerationService.getRules(normalizedFilters)
+        if (isMounted) {
+          setRules(data.sort((a, b) => a.priority - b.priority))
+        }
+      } catch (err) {
+        console.error('Failed to load moderation rules', err)
+        if (isMounted) {
+          setError('Impossible de charger les règles de modération.')
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchRules()
+
+    return () => {
+      isMounted = false
+    }
+  }, [normalizedFilters])
+
+  const handleToggle = async (rule: ModerationRule) => {
+    setIsSaving(true)
+    setError(null)
+    try {
+      const updated = await ModerationService.toggleRule(rule.id, !rule.enabled)
+      setRules(prev =>
+        prev.map(r => (r.id === updated.id ? { ...r, enabled: updated.enabled } : r))
+      )
+      onRulesUpdated?.()
+    } catch (err) {
+      console.error('Failed to toggle rule', err)
+      setError("Impossible de mettre à jour l'état de la règle.")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleMove = async (rule: ModerationRule, direction: -1 | 1) => {
+    const currentIndex = rules.findIndex(r => r.id === rule.id)
+    const targetIndex = currentIndex + direction
+
+    if (targetIndex < 0 || targetIndex >= rules.length) {
+      return
+    }
+
+    const reordered = [...rules]
+    const [moved] = reordered.splice(currentIndex, 1)
+    reordered.splice(targetIndex, 0, moved)
+
+    setRules(reordered)
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      await ModerationService.reorderRules(reordered.map(r => r.id))
+      onRulesUpdated?.()
+    } catch (err) {
+      console.error('Failed to reorder rules', err)
+      setError('La mise à jour de la priorité a échoué.')
+      setRules(rules)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div className="moderation-rules" data-testid="moderation-rules-editor">
+      <header className="moderation-rules__header">
+        <h3>Règles automatiques</h3>
+        {isSaving && <span>Synchronisation…</span>}
+      </header>
+      {isLoading && <p>Chargement des règles…</p>}
+      {error && <p className="moderation-dashboard__error">{error}</p>}
+      {!isLoading && !error && rules.length === 0 && <p>Aucune règle ne correspond aux filtres.</p>}
+      <ul className="moderation-rules__list">
+        {rules.map(rule => (
+          <li key={rule.id} className="moderation-rules__item">
+            <div className="moderation-rules__item-header">
+              <div>
+                <strong>{rule.name}</strong>
+                <p>{rule.description}</p>
+              </div>
+              <div className="moderation-rules__actions">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={rule.enabled}
+                    onChange={() => handleToggle(rule)}
+                    disabled={isSaving}
+                    data-testid={`rule-toggle-${rule.id}`}
+                  />
+                  Active
+                </label>
+                <button
+                  type="button"
+                  onClick={() => handleMove(rule, -1)}
+                  disabled={isSaving}
+                  aria-label="Priorité supérieure"
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleMove(rule, 1)}
+                  disabled={isSaving}
+                  aria-label="Priorité inférieure"
+                >
+                  ↓
+                </button>
+              </div>
+            </div>
+            <div className="moderation-rules__meta">
+              <span>Priorité : {rule.priority}</span>
+              <span>Sévérité : {rule.severity}</span>
+              {rule.lastTriggeredAt && (
+                <span>Dernier déclenchement : {new Date(rule.lastTriggeredAt).toLocaleString()}</span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/moderation/ReportedContentTable.tsx
+++ b/src/components/moderation/ReportedContentTable.tsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  MODERATION_STATUS_LABELS,
+  ModerationFilters,
+  ModerationService,
+  ReportedContent
+} from '../../services/moderationService'
+
+interface ReportedContentTableProps {
+  filters: ModerationFilters
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onSelectReport: (report: ReportedContent | null) => void
+  selectedReportId?: string
+}
+
+export function ReportedContentTable({
+  filters,
+  page,
+  pageSize,
+  onPageChange,
+  onSelectReport,
+  selectedReportId
+}: ReportedContentTableProps) {
+  const [reports, setReports] = useState<ReportedContent[]>([])
+  const [total, setTotal] = useState(0)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const requestId = useRef(0)
+
+  const normalizedFilters = useMemo(() => ({
+    ...filters,
+    status: filters.status === 'all' ? undefined : filters.status,
+    severity: filters.severity === 'all' ? undefined : filters.severity,
+    contentType: filters.contentType === 'all' ? undefined : filters.contentType,
+    ruleId: filters.ruleId || undefined
+  }), [filters])
+
+  useEffect(() => {
+    let isMounted = true
+    const currentRequest = requestId.current + 1
+    requestId.current = currentRequest
+
+    const fetchReports = async () => {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const { reports: data, total: totalCount } = await ModerationService.listReports({
+          ...normalizedFilters,
+          page,
+          pageSize
+        })
+
+        if (!isMounted || currentRequest !== requestId.current) {
+          return
+        }
+
+        setReports(data)
+        setTotal(totalCount)
+
+        if (data.length === 0 && page > 0) {
+          onPageChange(Math.max(0, page - 1))
+        }
+      } catch (err) {
+        console.error('Failed to load reported content', err)
+        if (isMounted) {
+          setError('Impossible de récupérer les signalements.')
+        }
+      } finally {
+        if (isMounted && currentRequest === requestId.current) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchReports()
+
+    return () => {
+      isMounted = false
+    }
+  }, [normalizedFilters, onPageChange, page, pageSize])
+
+  const totalPages = total > 0 ? Math.ceil(total / pageSize) : 0
+
+  return (
+    <div className="moderation-reports">
+      <header className="moderation-reports__header">
+        <h3>Signalements</h3>
+        <span>{total} résultat{total > 1 ? 's' : ''}</span>
+      </header>
+      {isLoading && <p>Chargement des signalements…</p>}
+      {error && <p className="moderation-dashboard__error">{error}</p>}
+      {!isLoading && !error && reports.length === 0 && <p>Aucun signalement pour ces filtres.</p>}
+      {!isLoading && !error && reports.length > 0 && (
+        <table className="moderation-reports__table" data-testid="reported-content-table">
+          <thead>
+            <tr>
+              <th>Contenu</th>
+              <th>Raison</th>
+              <th>Gravité</th>
+              <th>Statut</th>
+              <th>Assigné à</th>
+              <th>Signalé le</th>
+            </tr>
+          </thead>
+          <tbody>
+            {reports.map(report => {
+              const isSelected = report.id === selectedReportId
+              return (
+                <tr
+                  key={report.id}
+                  className={isSelected ? 'moderation-reports__row--selected' : undefined}
+                  onClick={() => onSelectReport(report)}
+                  tabIndex={0}
+                  role="button"
+                  onKeyDown={event => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      onSelectReport(report)
+                    }
+                  }}
+                  data-testid={`report-row-${report.id}`}
+                >
+                  <td>
+                    <div className="moderation-reports__snippet">{report.snippet}</div>
+                    <div className="moderation-reports__metadata">ID contenu : {report.contentId}</div>
+                  </td>
+                  <td>{report.reason}</td>
+                  <td className={`moderation-reports__severity--${report.severity}`}>{report.severity}</td>
+                  <td>{MODERATION_STATUS_LABELS[report.status]}</td>
+                  <td>{report.assignedTo || 'Non assigné'}</td>
+                  <td>{new Date(report.createdAt).toLocaleString()}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+      <footer className="moderation-reports__pagination">
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.max(0, page - 1))}
+          disabled={isLoading || page === 0}
+        >
+          Précédent
+        </button>
+        <span>
+          Page {totalPages === 0 ? 0 : page + 1} / {totalPages}
+        </span>
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={isLoading || totalPages === 0 || page + 1 >= totalPages}
+        >
+          Suivant
+        </button>
+      </footer>
+    </div>
+  )
+}

--- a/src/components/moderation/UserModerationPanel.tsx
+++ b/src/components/moderation/UserModerationPanel.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useState } from 'react'
+import {
+  MODERATION_STATUS_LABELS,
+  ModerationDecisionAction,
+  ModerationFilters,
+  ModerationService,
+  ReportedContent
+} from '../../services/moderationService'
+
+interface UserModerationPanelProps {
+  report: ReportedContent | null
+  onDecisionComplete: (report: ReportedContent) => void
+  filters: ModerationFilters
+}
+
+const ACTION_LABELS: Record<ModerationDecisionAction, string> = {
+  dismiss: 'Rejeter le signalement',
+  remove: 'Retirer le contenu',
+  restrict: 'Limiter la visibilité',
+  warn: 'Avertir le compte',
+  ban: 'Suspendre le compte',
+  escalate: 'Escalader vers un responsable'
+}
+
+export function UserModerationPanel({ report, onDecisionComplete, filters }: UserModerationPanelProps) {
+  const [action, setAction] = useState<ModerationDecisionAction>('remove')
+  const [comment, setComment] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    setAction('remove')
+    setComment('')
+    setError(null)
+    setSuccessMessage(null)
+  }, [report?.id])
+
+  const handleSubmit = async () => {
+    if (!report) {
+      return
+    }
+
+    if (!comment.trim()) {
+      setError('Un commentaire détaillant la décision est obligatoire.')
+      return
+    }
+
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const updated = await ModerationService.submitDecision(report.id, {
+        action,
+        comment: comment.trim(),
+        escalate: action === 'escalate'
+      })
+
+      onDecisionComplete(updated)
+      setSuccessMessage('Décision enregistrée avec succès.')
+    } catch (err) {
+      console.error('Failed to submit moderation decision', err)
+      setError("Impossible d'enregistrer la décision. Réessayez plus tard.")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (!report) {
+    return (
+      <div className="moderation-panel" data-testid="moderation-panel-empty">
+        <h3>Revue de contenu</h3>
+        <p>Sélectionnez un signalement pour afficher les détails et prendre une décision.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="moderation-panel" data-testid="moderation-panel">
+      <header className="moderation-panel__header">
+        <h3>Revue de contenu</h3>
+        <span className={`moderation-panel__status moderation-panel__status--${report.status}`}>
+          {MODERATION_STATUS_LABELS[report.status]}
+        </span>
+      </header>
+
+      <section className="moderation-panel__section">
+        <h4>Contenu signalé</h4>
+        <p className="moderation-panel__snippet">{report.snippet}</p>
+        <dl className="moderation-panel__details">
+          <div>
+            <dt>Type</dt>
+            <dd>{report.contentType}</dd>
+          </div>
+          <div>
+            <dt>Gravité</dt>
+            <dd>{report.severity}</dd>
+          </div>
+          <div>
+            <dt>Raison</dt>
+            <dd>{report.reason}</dd>
+          </div>
+          <div>
+            <dt>Signalé par</dt>
+            <dd>{report.reporterName || report.reporterId}</dd>
+          </div>
+          <div>
+            <dt>Date</dt>
+            <dd>{new Date(report.createdAt).toLocaleString()}</dd>
+          </div>
+        </dl>
+        {report.evidenceUrls && report.evidenceUrls.length > 0 && (
+          <div className="moderation-panel__evidence">
+            <h5>Preuves fournies</h5>
+            <ul>
+              {report.evidenceUrls.map(url => (
+                <li key={url}>
+                  <a href={url} target="_blank" rel="noreferrer">
+                    Consulter la preuve
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <section className="moderation-panel__section">
+        <h4>Décision</h4>
+        <label htmlFor="moderation-action">Action</label>
+        <select
+          id="moderation-action"
+          value={action}
+          onChange={event => {
+            setAction(event.target.value as ModerationDecisionAction)
+            setSuccessMessage(null)
+          }}
+          data-testid="moderation-action-select"
+        >
+          {Object.entries(ACTION_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+
+        <label htmlFor="moderation-comment">Commentaire *</label>
+        <textarea
+          id="moderation-comment"
+          value={comment}
+          onChange={event => {
+            setComment(event.target.value)
+            setError(null)
+            setSuccessMessage(null)
+          }}
+          placeholder="Expliquez la décision prise et la suite prévue"
+          rows={4}
+          required
+          data-testid="moderation-comment"
+        />
+
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={isSubmitting || !comment.trim()}
+          data-testid="moderation-submit"
+        >
+          {isSubmitting ? 'Enregistrement…' : 'Appliquer la décision'}
+        </button>
+
+        {error && <p className="moderation-dashboard__error">{error}</p>}
+        {successMessage && <p className="moderation-panel__success">{successMessage}</p>}
+      </section>
+
+      <footer className="moderation-panel__footer">
+        <h4>Contexte des filtres</h4>
+        <ul>
+          <li>Statut filtré : {filters.status || 'Tous'}</li>
+          <li>Gravité filtrée : {filters.severity || 'Toutes'}</li>
+          <li>Type filtré : {filters.contentType || 'Tous'}</li>
+        </ul>
+      </footer>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -130,3 +130,292 @@ body {
 .user-card button {
   margin-top: 0.5rem;
 }
+
+.moderation-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.moderation-dashboard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #fff;
+  padding: 16px 24px;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.moderation-dashboard__header h2 {
+  margin: 0 0 4px;
+}
+
+.moderation-dashboard__filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  background: #fff;
+  padding: 16px;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.moderation-dashboard__filters input,
+.moderation-dashboard__filters select {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  min-width: 180px;
+}
+
+.moderation-dashboard__filters button,
+.moderation-dashboard__export button,
+.moderation-panel button,
+.moderation-rules__actions button,
+.moderation-appeals__actions button,
+.moderation-reports__pagination button,
+.moderation-appeals__pagination button {
+  background-color: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.moderation-dashboard__filters button:hover,
+.moderation-dashboard__export button:hover,
+.moderation-panel button:hover,
+.moderation-rules__actions button:hover,
+.moderation-appeals__actions button:hover,
+.moderation-reports__pagination button:hover,
+.moderation-appeals__pagination button:hover {
+  background-color: #1d4ed8;
+}
+
+.moderation-dashboard__filters button:disabled,
+.moderation-dashboard__export button:disabled,
+.moderation-panel button:disabled,
+.moderation-rules__actions button:disabled,
+.moderation-appeals__actions button:disabled,
+.moderation-reports__pagination button:disabled,
+.moderation-appeals__pagination button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.moderation-dashboard__main {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
+.moderation-dashboard__reports,
+.moderation-dashboard__panel,
+.moderation-dashboard__secondary > * {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.moderation-dashboard__panel,
+.moderation-dashboard__reports {
+  padding: 16px;
+}
+
+.moderation-dashboard__secondary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.moderation-dashboard__audit {
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.moderation-dashboard__audit-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.moderation-dashboard__audit-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.moderation-dashboard__audit-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.moderation-dashboard__audit-meta,
+.moderation-dashboard__audit-target {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.moderation-dashboard__error {
+  color: #b91c1c;
+  font-weight: 500;
+}
+
+.moderation-reports__header,
+.moderation-reports__pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.moderation-reports__table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 12px;
+}
+
+.moderation-reports__table th,
+.moderation-reports__table td {
+  border-bottom: 1px solid #e5e7eb;
+  padding: 10px;
+  text-align: left;
+}
+
+.moderation-reports__row--selected {
+  background-color: rgba(37, 99, 235, 0.08);
+}
+
+.moderation-reports__severity--low {
+  color: #047857;
+}
+
+.moderation-reports__severity--medium {
+  color: #b45309;
+}
+
+.moderation-reports__severity--high {
+  color: #dc2626;
+}
+
+.moderation-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.moderation-panel__section {
+  margin-top: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.moderation-panel__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.moderation-panel__details dt {
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.moderation-panel__snippet {
+  font-style: italic;
+  color: #374151;
+}
+
+.moderation-panel textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  resize: vertical;
+}
+
+.moderation-panel__success {
+  color: #15803d;
+  font-weight: 500;
+}
+
+.moderation-panel__footer ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 4px;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.moderation-rules__list,
+.moderation-appeals__list {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: grid;
+  gap: 12px;
+}
+
+.moderation-rules__item,
+.moderation-appeals__item {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.moderation-rules__item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.moderation-rules__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.moderation-rules__actions input[type='checkbox'] {
+  margin-right: 4px;
+}
+
+.moderation-rules__actions button {
+  padding: 4px 8px;
+}
+
+.moderation-appeals__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.moderation-appeals__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.moderation-appeals__notes {
+  font-size: 0.9rem;
+  color: #4b5563;
+}

--- a/src/services/moderationService.ts
+++ b/src/services/moderationService.ts
@@ -1,0 +1,237 @@
+import axios from 'axios'
+
+const API = import.meta.env.VITE_API_BASE_URL
+
+export type ModerationStatus =
+  | 'pending'
+  | 'under_review'
+  | 'action_taken'
+  | 'dismissed'
+  | 'escalated'
+
+export type ModerationSeverity = 'low' | 'medium' | 'high'
+
+export const MODERATION_STATUS_LABELS: Record<ModerationStatus, string> = {
+  pending: 'En attente',
+  under_review: 'En cours',
+  action_taken: 'Action effectuée',
+  dismissed: 'Rejeté',
+  escalated: 'Escaladé'
+}
+
+export interface ModerationFilters {
+  search?: string
+  status?: ModerationStatus | 'all'
+  severity?: ModerationSeverity | 'all'
+  contentType?: string
+  ruleId?: string
+}
+
+export interface ReportedContent {
+  id: string
+  contentId: string
+  contentType: string
+  snippet: string
+  reporterId: string
+  reporterName?: string
+  reason: string
+  status: ModerationStatus
+  severity: ModerationSeverity
+  assignedTo?: string
+  evidenceUrls?: string[]
+  createdAt: string
+  updatedAt?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface ReportListParams extends ModerationFilters {
+  page?: number
+  pageSize?: number
+  sort?: string
+  assignedTo?: string
+}
+
+export type ModerationDecisionAction =
+  | 'dismiss'
+  | 'remove'
+  | 'restrict'
+  | 'warn'
+  | 'ban'
+  | 'escalate'
+
+export interface ModerationDecisionPayload {
+  action: ModerationDecisionAction
+  comment: string
+  escalate?: boolean
+  metadata?: Record<string, unknown>
+}
+
+export interface ModerationRule {
+  id: string
+  name: string
+  description?: string
+  enabled: boolean
+  priority: number
+  severity: ModerationSeverity
+  conditions: Record<string, unknown>
+  actions: Record<string, unknown>
+  lastTriggeredAt?: string
+}
+
+export interface ModerationRuleInput {
+  name: string
+  description?: string
+  severity: ModerationSeverity
+  conditions: Record<string, unknown>
+  actions: Record<string, unknown>
+}
+
+export interface AuditTrailEntry {
+  id: string
+  timestamp: string
+  actor: string
+  action: string
+  targetId: string
+  targetType: string
+  details?: Record<string, unknown>
+  status?: ModerationStatus
+}
+
+export interface ModerationAppeal {
+  id: string
+  reportId: string
+  userId: string
+  userName?: string
+  submittedAt: string
+  status: 'pending' | 'approved' | 'rejected'
+  notes?: string
+  decision?: string
+  lastUpdatedAt?: string
+}
+
+export interface AuditTrailParams extends ModerationFilters {
+  page?: number
+  pageSize?: number
+}
+
+export interface AppealsParams extends ModerationFilters {
+  page?: number
+  pageSize?: number
+  status?: ModerationAppeal['status'] | 'all'
+}
+
+export const ModerationService = {
+  async listReports(params: ReportListParams) {
+    const query = {
+      ...params,
+      status: params.status && params.status !== 'all' ? params.status : undefined,
+      severity: params.severity && params.severity !== 'all' ? params.severity : undefined,
+      contentType: params.contentType && params.contentType !== 'all' ? params.contentType : undefined,
+      ruleId: params.ruleId || undefined
+    }
+
+    const { data } = await axios.get(`${API}/api/moderation/reports`, { params: query })
+    return data as { reports: ReportedContent[]; total: number }
+  },
+
+  async getReport(reportId: string) {
+    const { data } = await axios.get(`${API}/api/moderation/reports/${reportId}`)
+    return data as ReportedContent
+  },
+
+  async submitDecision(reportId: string, payload: ModerationDecisionPayload) {
+    const { data } = await axios.post(`${API}/api/moderation/reports/${reportId}/decisions`, payload)
+    return data as ReportedContent
+  },
+
+  async assignReport(reportId: string, assigneeId: string) {
+    const { data } = await axios.post(`${API}/api/moderation/reports/${reportId}/assign`, { assigneeId })
+    return data as ReportedContent
+  },
+
+  async getRules(params?: Partial<ModerationFilters>) {
+    const query = params
+      ? {
+          ...params,
+          status: params.status && params.status !== 'all' ? params.status : undefined,
+          severity: params.severity && params.severity !== 'all' ? params.severity : undefined,
+          contentType: params.contentType && params.contentType !== 'all' ? params.contentType : undefined,
+          ruleId: params.ruleId || undefined
+        }
+      : undefined
+
+    const { data } = await axios.get(`${API}/api/moderation/rules`, { params: query })
+    return data as ModerationRule[]
+  },
+
+  async createRule(input: ModerationRuleInput) {
+    const { data } = await axios.post(`${API}/api/moderation/rules`, input)
+    return data as ModerationRule
+  },
+
+  async updateRule(ruleId: string, input: Partial<ModerationRuleInput>) {
+    const { data } = await axios.put(`${API}/api/moderation/rules/${ruleId}`, input)
+    return data as ModerationRule
+  },
+
+  async toggleRule(ruleId: string, enabled: boolean) {
+    const { data } = await axios.post(`${API}/api/moderation/rules/${ruleId}/toggle`, { enabled })
+    return data as ModerationRule
+  },
+
+  async reorderRules(order: string[]) {
+    const { data } = await axios.post(`${API}/api/moderation/rules/reorder`, { order })
+    return data as ModerationRule[]
+  },
+
+  async deleteRule(ruleId: string) {
+    await axios.delete(`${API}/api/moderation/rules/${ruleId}`)
+  },
+
+  async getAuditTrail(params: AuditTrailParams) {
+    const query = {
+      ...params,
+      status: params.status && params.status !== 'all' ? params.status : undefined,
+      severity: params.severity && params.severity !== 'all' ? params.severity : undefined,
+      contentType: params.contentType && params.contentType !== 'all' ? params.contentType : undefined,
+      ruleId: params.ruleId || undefined
+    }
+
+    const { data } = await axios.get(`${API}/api/moderation/audit`, { params: query })
+    return data as { entries: AuditTrailEntry[]; total: number }
+  },
+
+  async exportAuditTrail(format: 'json' | 'csv', params: AuditTrailParams) {
+    const query = {
+      ...params,
+      status: params.status && params.status !== 'all' ? params.status : undefined,
+      severity: params.severity && params.severity !== 'all' ? params.severity : undefined,
+      contentType: params.contentType && params.contentType !== 'all' ? params.contentType : undefined,
+      ruleId: params.ruleId || undefined
+    }
+
+    const response = await axios.get(`${API}/api/moderation/audit/export`, {
+      params: { ...query, format },
+      responseType: 'blob'
+    })
+    return response.data as Blob
+  },
+
+  async listAppeals(params: AppealsParams) {
+    const query = {
+      ...params,
+      status: params.status && params.status !== 'all' ? params.status : undefined,
+      severity: params.severity && params.severity !== 'all' ? params.severity : undefined,
+      contentType: params.contentType && params.contentType !== 'all' ? params.contentType : undefined,
+      ruleId: params.ruleId || undefined
+    }
+
+    const { data } = await axios.get(`${API}/api/moderation/appeals`, { params: query })
+    return data as { appeals: ModerationAppeal[]; total: number }
+  },
+
+  async updateAppeal(appealId: string, payload: { status: ModerationAppeal['status']; notes?: string }) {
+    const { data } = await axios.post(`${API}/api/moderation/appeals/${appealId}`, payload)
+    return data as ModerationAppeal
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a moderation service to retrieve reports, rules, audit trail and appeals with status handling
- implement a moderation dashboard UI with shared filters, review workflow, rule editor, appeals queue and updated styling
- add moderation test coverage for navigation and actions

## Testing
- npx vitest run src/__tests__/moderation.test.tsx --environment jsdom

------
https://chatgpt.com/codex/tasks/task_e_68d9b962dacc833284d9736ada5cf990