### PR TITLE
Add financial analytics dashboard service, UI, and tests

### DIFF
--- a/src/__tests__/financialDashboard.test.tsx
+++ b/src/__tests__/financialDashboard.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { FinancialService, type FinancialFilters } from '../services/financialService'
+
+describe('Financial dashboard aggregations', () => {
+  const baseFilters: FinancialFilters = {
+    granularity: 'month',
+    plan: 'all',
+    priceVariation: 0,
+    startDate: '2024-07-01',
+    endDate: '2024-09-30'
+  }
+
+  it('applies price variation to revenue trend', async () => {
+    const data = await FinancialService.getRevenueTrend({ ...baseFilters, priceVariation: 10 })
+    expect(data).toHaveLength(3)
+    expect(data[0].period).toBe('2024-07')
+    expect(data[0].revenue).toBeCloseTo(70840, 2)
+    expect(data[0].arpu).toBeCloseTo(85.35, 2)
+  })
+
+  it('aggregates subscription metrics per plan', async () => {
+    const metrics = await FinancialService.getSubscriptionMetrics({ ...baseFilters, plan: 'basic' })
+    expect(metrics).toHaveLength(1)
+    const [basic] = metrics
+    expect(basic.activeSubscribers).toBe(423)
+    expect(basic.newSubscriptions).toBe(255)
+    expect(basic.churnedSubscriptions).toBe(55)
+    expect(basic.arpu).toBeCloseTo(30, 2)
+  })
+
+  it('aggregates cost metrics with revenue comparison', async () => {
+    const costMetrics = await FinancialService.getCostMetrics(baseFilters)
+    const marketing = costMetrics.categories.find((category) => category.category === 'Marketing')
+    expect(marketing?.amount).toBeCloseTo(29250, 2)
+    expect(costMetrics.comparison[0]).toMatchObject({ period: '2024-07', cost: 21600, revenue: 64400 })
+    expect(costMetrics.comparison[2]).toMatchObject({ period: '2024-09', cost: 21780, revenue: 69900 })
+  })
+
+  it('calculates business KPIs across periods', async () => {
+    const kpis = await FinancialService.getBusinessKpis(baseFilters)
+    const mrr = kpis.find((kpi) => kpi.label === 'MRR')
+    const grossMargin = kpis.find((kpi) => kpi.label === 'Gross Margin')
+    expect(mrr?.value).toBeCloseTo(69900, 2)
+    expect(mrr?.delta).toBeCloseTo(2900, 2)
+    expect(grossMargin?.value).toBeGreaterThan(60)
+    expect(grossMargin?.value).toBeLessThan(80)
+  })
+
+  it('exports aggregated data to multiple formats', async () => {
+    const csvBlob = await FinancialService.exportFinancialData('csv', baseFilters)
+    const csvContent = await csvBlob.text()
+    expect(csvContent).toContain('period,revenue,arpu,payingUsers,benefit')
+    expect(csvContent).toContain('2024-07')
+
+    const excelBlob = await FinancialService.exportFinancialData('excel', baseFilters)
+    const excelContent = await excelBlob.text()
+    expect(excelContent).toContain('Financial Report')
+    expect(excelContent).toContain('Revenue Trend')
+
+    const pdfBlob = await FinancialService.exportFinancialData('pdf', baseFilters)
+    const pdfContent = await pdfBlob.text()
+    expect(pdfContent).toContain('Financial Report')
+    expect(pdfContent).toContain('Revenue:')
+  })
+})

--- a/src/components/finance/BusinessKpiCards.tsx
+++ b/src/components/finance/BusinessKpiCards.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { BusinessKpi } from '../../services/financialService'
+
+interface BusinessKpiCardsProps {
+  kpis: BusinessKpi[]
+}
+
+const formatValue = (kpi: BusinessKpi) => {
+  if (kpi.format === 'currency') {
+    return `€${kpi.value.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+  }
+
+  if (kpi.format === 'percentage') {
+    return `${kpi.value.toFixed(2)}%`
+  }
+
+  return kpi.value.toFixed(2)
+}
+
+const formatDelta = (kpi: BusinessKpi) => {
+  if (kpi.delta === 0) {
+    return null
+  }
+
+  const prefix = kpi.delta > 0 ? '+' : ''
+
+  if (kpi.format === 'currency') {
+    return `${prefix}€${kpi.delta.toFixed(2)}`
+  }
+
+  return `${prefix}${kpi.delta.toFixed(2)}${kpi.format === 'percentage' ? '%' : ''}`
+}
+
+export const BusinessKpiCards: React.FC<BusinessKpiCardsProps> = ({ kpis }) => {
+  if (!kpis.length) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-6 text-center text-sm text-slate-500">
+        KPIs en cours de calcul...
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {kpis.map((kpi) => {
+        const deltaText = formatDelta(kpi)
+        return (
+          <div key={kpi.label} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-xs uppercase tracking-wide text-slate-500">{kpi.label}</div>
+            <div className="mt-2 text-2xl font-semibold text-slate-900">{formatValue(kpi)}</div>
+            {deltaText && (
+              <div className={`mt-1 text-sm ${kpi.delta >= 0 ? 'text-emerald-600' : 'text-rose-600'}`}>{deltaText}</div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/finance/CostInsights.tsx
+++ b/src/components/finance/CostInsights.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useMemo, useRef } from 'react'
+import * as d3 from 'd3'
+import { CostMetrics } from '../../services/financialService'
+
+interface CostInsightsProps {
+  data: CostMetrics
+}
+
+export const CostInsights: React.FC<CostInsightsProps> = ({ data }) => {
+  const comparisonRef = useRef<SVGSVGElement | null>(null)
+  const categoriesRef = useRef<SVGSVGElement | null>(null)
+
+  const totals = useMemo(() => {
+    const totalCost = data.categories.reduce((sum, category) => sum + category.amount, 0)
+    const lastComparison = data.comparison[data.comparison.length - 1]
+    const margin = lastComparison ? lastComparison.revenue - lastComparison.cost : 0
+    return {
+      totalCost,
+      margin
+    }
+  }, [data])
+
+  useEffect(() => {
+    if (!comparisonRef.current) {
+      return
+    }
+
+    const svg = d3.select(comparisonRef.current)
+    const width = 500
+    const height = 280
+    const margin = { top: 24, right: 16, bottom: 48, left: 56 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+    svg.selectAll('*').remove()
+
+    if (data.comparison.length === 0) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text('Aucune donnée de coûts disponible.')
+      return
+    }
+
+    const chartWidth = width - margin.left - margin.right
+    const chartHeight = height - margin.top - margin.bottom
+    const container = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    const xScale = d3
+      .scaleBand()
+      .domain(data.comparison.map((point) => point.period))
+      .range([0, chartWidth])
+      .padding(0.35)
+
+    const maxValue = d3.max(data.comparison, (point) => Math.max(point.cost, point.revenue)) ?? 0
+    const yScale = d3.scaleLinear().domain([0, maxValue * 1.1]).range([chartHeight, 0]).nice()
+
+    container
+      .append('g')
+      .attr('transform', `translate(0,${chartHeight})`)
+      .call(d3.axisBottom(xScale))
+
+    container.append('g').call(d3.axisLeft(yScale).ticks(6))
+
+    container
+      .selectAll('.bar-cost')
+      .data(data.comparison)
+      .enter()
+      .append('rect')
+      .attr('class', 'bar-cost')
+      .attr('x', (d) => xScale(d.period) ?? 0)
+      .attr('y', (d) => yScale(d.cost))
+      .attr('width', xScale.bandwidth() / 2)
+      .attr('height', (d) => chartHeight - yScale(d.cost))
+      .attr('fill', '#dc2626')
+      .attr('rx', 6)
+
+    container
+      .selectAll('.bar-revenue')
+      .data(data.comparison)
+      .enter()
+      .append('rect')
+      .attr('class', 'bar-revenue')
+      .attr('x', (d) => (xScale(d.period) ?? 0) + xScale.bandwidth() / 2)
+      .attr('y', (d) => yScale(d.revenue))
+      .attr('width', xScale.bandwidth() / 2)
+      .attr('height', (d) => chartHeight - yScale(d.revenue))
+      .attr('fill', '#2563eb')
+      .attr('rx', 6)
+
+    const legend = svg.append('g').attr('transform', `translate(${width - 160}, 16)`)
+
+    legend
+      .append('rect')
+      .attr('width', 12)
+      .attr('height', 12)
+      .attr('fill', '#dc2626')
+
+    legend
+      .append('text')
+      .attr('x', 20)
+      .attr('y', 10)
+      .attr('fill', '#374151')
+      .attr('font-size', 12)
+      .text('Coûts')
+
+    legend
+      .append('rect')
+      .attr('x', 0)
+      .attr('y', 24)
+      .attr('width', 12)
+      .attr('height', 12)
+      .attr('fill', '#2563eb')
+
+    legend
+      .append('text')
+      .attr('x', 20)
+      .attr('y', 34)
+      .attr('fill', '#374151')
+      .attr('font-size', 12)
+      .text('Revenus')
+  }, [data.comparison])
+
+  useEffect(() => {
+    if (!categoriesRef.current) {
+      return
+    }
+
+    const svg = d3.select(categoriesRef.current)
+    const width = 500
+    const height = 240
+    const margin = { top: 24, right: 16, bottom: 36, left: 160 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+    svg.selectAll('*').remove()
+
+    if (data.categories.length === 0) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text('Pas de catégories de coût disponibles.')
+      return
+    }
+
+    const chartWidth = width - margin.left - margin.right
+    const chartHeight = height - margin.top - margin.bottom
+
+    const yScale = d3
+      .scaleBand()
+      .domain(data.categories.map((category) => category.category))
+      .range([0, chartHeight])
+      .padding(0.2)
+
+    const xScale = d3
+      .scaleLinear()
+      .domain([0, d3.max(data.categories, (category) => category.amount) ?? 0])
+      .range([0, chartWidth])
+      .nice()
+
+    const container = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    container.append('g').call(d3.axisLeft(yScale))
+
+    container
+      .append('g')
+      .attr('transform', `translate(0,${chartHeight})`)
+      .call(d3.axisBottom(xScale).ticks(5))
+
+    container
+      .selectAll('rect')
+      .data(data.categories)
+      .enter()
+      .append('rect')
+      .attr('x', 0)
+      .attr('y', (d) => yScale(d.category) ?? 0)
+      .attr('width', (d) => xScale(d.amount))
+      .attr('height', yScale.bandwidth())
+      .attr('fill', '#9333ea')
+      .attr('rx', 6)
+
+    container
+      .selectAll('text.value')
+      .data(data.categories)
+      .enter()
+      .append('text')
+      .attr('class', 'value')
+      .attr('x', (d) => xScale(d.amount) + 8)
+      .attr('y', (d) => (yScale(d.category) ?? 0) + yScale.bandwidth() / 2 + 4)
+      .attr('fill', '#4b5563')
+      .attr('font-size', 12)
+      .text((d) => `€${d.amount.toFixed(0)}`)
+  }, [data.categories])
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="mb-4 flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Coûts et bénéfices</h2>
+          <p className="text-sm text-slate-500">
+            Comparez les coûts par période et identifiez les gains de marge sur les segments actifs.
+          </p>
+        </div>
+        <div className="text-right text-sm text-slate-600">
+          <div>
+            Coûts totaux: <span className="font-semibold text-slate-900">€{totals.totalCost.toLocaleString('fr-FR', { maximumFractionDigits: 0 })}</span>
+          </div>
+          <div>
+            Marge dernière période: <span className={totals.margin >= 0 ? 'text-emerald-600 font-semibold' : 'text-rose-600 font-semibold'}>
+              €{totals.margin.toLocaleString('fr-FR', { maximumFractionDigits: 0 })}
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-6">
+        <div>
+          <h3 className="text-sm font-medium text-slate-700">Comparaison coûts vs revenus</h3>
+          <svg ref={comparisonRef} className="mt-2 w-full" role="img" aria-label="Comparaison coûts vs revenus" />
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-slate-700">Répartition des coûts</h3>
+          <svg ref={categoriesRef} className="mt-2 w-full" role="img" aria-label="Répartition des coûts" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/finance/FinancialDashboard.tsx
+++ b/src/components/finance/FinancialDashboard.tsx
@@ -1,0 +1,318 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import * as d3 from 'd3'
+import {
+  BusinessKpi,
+  CostMetrics,
+  ExportFormat,
+  FinancialService,
+  PlanFilter,
+  RevenueTrendPoint,
+  SubscriptionMetric,
+  TimeGranularity,
+  CohortPoint
+} from '../../services/financialService'
+import { SubscriptionManager } from './SubscriptionManager'
+import { CostInsights } from './CostInsights'
+import { BusinessKpiCards } from './BusinessKpiCards'
+
+interface DashboardState {
+  revenueTrend: RevenueTrendPoint[]
+  subscriptionMetrics: SubscriptionMetric[]
+  costMetrics: CostMetrics
+  cohortData: CohortPoint[]
+  kpis: BusinessKpi[]
+}
+
+const defaultState: DashboardState = {
+  revenueTrend: [],
+  subscriptionMetrics: [],
+  costMetrics: { categories: [], comparison: [] },
+  cohortData: [],
+  kpis: []
+}
+
+export const FinancialDashboard: React.FC = () => {
+  const [granularity, setGranularity] = useState<TimeGranularity>('month')
+  const [plan, setPlan] = useState<PlanFilter>('all')
+  const [priceVariation, setPriceVariation] = useState(0)
+  const [startDate, setStartDate] = useState('2024-07-01')
+  const [endDate, setEndDate] = useState('2024-09-30')
+  const [state, setState] = useState<DashboardState>(defaultState)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const revenueChartRef = useRef<SVGSVGElement | null>(null)
+  const planOptions = useMemo(() => ['all', ...FinancialService.getPlanOptions()], [])
+
+  const filters = useMemo(
+    () => ({ granularity, plan, priceVariation, startDate, endDate }),
+    [granularity, plan, priceVariation, startDate, endDate]
+  )
+
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [revenueTrend, subscriptionMetrics, costMetrics, cohortData, kpis] = await Promise.all([
+        FinancialService.getRevenueTrend(filters),
+        FinancialService.getSubscriptionMetrics(filters),
+        FinancialService.getCostMetrics(filters),
+        FinancialService.getCohortRetention(filters),
+        FinancialService.getBusinessKpis(filters)
+      ])
+
+      setState({ revenueTrend, subscriptionMetrics, costMetrics, cohortData, kpis })
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Une erreur est survenue lors du chargement des données financières."
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [filters])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  useEffect(() => {
+    if (!revenueChartRef.current) {
+      return
+    }
+
+    const svg = d3.select(revenueChartRef.current)
+    const width = 720
+    const height = 320
+    const margin = { top: 30, right: 24, bottom: 48, left: 72 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+    svg.selectAll('*').remove()
+
+    if (state.revenueTrend.length === 0) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text('Aucune donnée disponible pour les filtres sélectionnés.')
+      return
+    }
+
+    const chartWidth = width - margin.left - margin.right
+    const chartHeight = height - margin.top - margin.bottom
+    const container = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    const xScale = d3
+      .scalePoint<string>()
+      .domain(state.revenueTrend.map((point) => point.period))
+      .range([0, chartWidth])
+      .padding(0.5)
+
+    const yMax = d3.max(state.revenueTrend, (d) => d.revenue) ?? 0
+    const yScale = d3.scaleLinear().domain([0, yMax * 1.1]).range([chartHeight, 0]).nice()
+
+    const lineGenerator = d3
+      .line<RevenueTrendPoint>()
+      .x((d) => xScale(d.period) ?? 0)
+      .y((d) => yScale(d.revenue))
+      .curve(d3.curveMonotoneX)
+
+    const areaGenerator = d3
+      .area<RevenueTrendPoint>()
+      .x((d) => xScale(d.period) ?? 0)
+      .y0(chartHeight)
+      .y1((d) => yScale(d.revenue))
+      .curve(d3.curveMonotoneX)
+
+    container
+      .append('path')
+      .datum(state.revenueTrend)
+      .attr('fill', 'rgba(37, 99, 235, 0.15)')
+      .attr('d', areaGenerator)
+
+    container
+      .append('path')
+      .datum(state.revenueTrend)
+      .attr('fill', 'none')
+      .attr('stroke', '#2563eb')
+      .attr('stroke-width', 2.5)
+      .attr('d', lineGenerator)
+
+    container
+      .selectAll('circle')
+      .data(state.revenueTrend)
+      .enter()
+      .append('circle')
+      .attr('cx', (d) => xScale(d.period) ?? 0)
+      .attr('cy', (d) => yScale(d.revenue))
+      .attr('r', 5)
+      .attr('fill', '#1d4ed8')
+      .attr('stroke', '#ffffff')
+      .attr('stroke-width', 2)
+
+    container
+      .append('g')
+      .attr('transform', `translate(0,${chartHeight})`)
+      .call(d3.axisBottom(xScale))
+
+    container.append('g').call(d3.axisLeft(yScale).ticks(6).tickFormat((d) => `${Number(d) / 1000}k`))
+
+    container
+      .append('text')
+      .attr('x', chartWidth / 2)
+      .attr('y', chartHeight + 36)
+      .attr('text-anchor', 'middle')
+      .attr('fill', '#4b5563')
+      .text('Période')
+
+    container
+      .append('text')
+      .attr('transform', 'rotate(-90)')
+      .attr('x', -chartHeight / 2)
+      .attr('y', -48)
+      .attr('text-anchor', 'middle')
+      .attr('fill', '#4b5563')
+      .text('Revenus (EUR)')
+  }, [state.revenueTrend])
+
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      try {
+        const blob = await FinancialService.exportFinancialData(format, filters)
+        const url = URL.createObjectURL(blob)
+        const extension = format === 'excel' ? 'xls' : format
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `financial-report.${extension}`
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+        URL.revokeObjectURL(url)
+      } catch (err) {
+        setError("Erreur lors de l'export des données financières.")
+      }
+    },
+    [filters]
+  )
+
+  return (
+    <div className="space-y-6">
+      <header className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900">Tableau de bord financier</h1>
+            <p className="text-sm text-slate-500">
+              Analysez les revenus, abonnements et coûts par période et par segment.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="text-sm text-slate-500">
+              Prix (%):
+              <input
+                type="range"
+                min={-30}
+                max={50}
+                value={priceVariation}
+                onChange={(event) => setPriceVariation(Number(event.target.value))}
+                className="ml-2 align-middle"
+              />
+              <span className="ml-2 font-medium text-slate-700">{priceVariation}%</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => handleExport('csv')}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Export CSV
+            </button>
+            <button
+              type="button"
+              onClick={() => handleExport('excel')}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Export Excel
+            </button>
+            <button
+              type="button"
+              onClick={() => handleExport('pdf')}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Export PDF
+            </button>
+          </div>
+        </div>
+        <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div>
+            <label className="text-xs uppercase tracking-wide text-slate-500">Granularité</label>
+            <select
+              value={granularity}
+              onChange={(event) => setGranularity(event.target.value as TimeGranularity)}
+              className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700"
+            >
+              <option value="day">Jour</option>
+              <option value="week">Semaine</option>
+              <option value="month">Mois</option>
+            </select>
+          </div>
+          <div>
+            <label className="text-xs uppercase tracking-wide text-slate-500">Segment</label>
+            <select
+              value={plan}
+              onChange={(event) => setPlan(event.target.value as PlanFilter)}
+              className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700"
+            >
+              {planOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option === 'all' ? 'Tous les plans' : option}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs uppercase tracking-wide text-slate-500">Date de début</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+              className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700"
+            />
+          </div>
+          <div>
+            <label className="text-xs uppercase tracking-wide text-slate-500">Date de fin</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+              className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700"
+            />
+          </div>
+        </div>
+      </header>
+
+      {error && <div className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">{error}</div>}
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Revenus</h2>
+            <p className="text-sm text-slate-500">
+              Courbe d'évolution des revenus agrégés avec variation de prix instantanée.
+            </p>
+          </div>
+          {loading && <span className="text-sm text-slate-400">Chargement...</span>}
+        </div>
+        <svg ref={revenueChartRef} className="mt-4 w-full" role="img" aria-label="Évolution des revenus" />
+      </section>
+
+      <BusinessKpiCards kpis={state.kpis} />
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <SubscriptionManager metrics={state.subscriptionMetrics} cohorts={state.cohortData} granularity={granularity} />
+        <CostInsights data={state.costMetrics} />
+      </section>
+    </div>
+  )
+}

--- a/src/components/finance/SubscriptionManager.tsx
+++ b/src/components/finance/SubscriptionManager.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useMemo, useRef } from 'react'
+import * as d3 from 'd3'
+import { CohortPoint, SubscriptionMetric, TimeGranularity } from '../../services/financialService'
+
+interface SubscriptionManagerProps {
+  metrics: SubscriptionMetric[]
+  cohorts: CohortPoint[]
+  granularity: TimeGranularity
+}
+
+export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({ metrics, cohorts, granularity }) => {
+  const histogramRef = useRef<SVGSVGElement | null>(null)
+  const heatmapRef = useRef<SVGSVGElement | null>(null)
+
+  const totals = useMemo(() => {
+    const active = metrics.reduce((sum, metric) => sum + metric.activeSubscribers, 0)
+    const newSubs = metrics.reduce((sum, metric) => sum + metric.newSubscriptions, 0)
+    const churn = metrics.reduce((sum, metric) => sum + metric.churnedSubscriptions, 0)
+    const arpuAverage = metrics.reduce((sum, metric) => sum + metric.arpu, 0) / (metrics.length || 1)
+    return {
+      active,
+      newSubs,
+      churn,
+      arpu: Number(arpuAverage.toFixed(2))
+    }
+  }, [metrics])
+
+  useEffect(() => {
+    if (!histogramRef.current) {
+      return
+    }
+
+    const svg = d3.select(histogramRef.current)
+    const width = 380
+    const height = 260
+    const margin = { top: 24, right: 16, bottom: 36, left: 48 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+    svg.selectAll('*').remove()
+
+    if (metrics.length === 0) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text("Aucune donnée d'abonnement.")
+      return
+    }
+
+    const chartWidth = width - margin.left - margin.right
+    const chartHeight = height - margin.top - margin.bottom
+
+    const arpuValues = metrics.map((metric) => metric.arpu)
+    const domainMin = d3.min(arpuValues) ?? 0
+    const domainMax = d3.max(arpuValues) ?? 0
+
+    const bins = d3
+      .bin()
+      .domain([domainMin, domainMax])
+      .thresholds(5)(arpuValues)
+
+    const xScale = d3.scaleLinear().domain([domainMin, domainMax]).range([0, chartWidth]).nice()
+
+    const yScale = d3
+      .scaleLinear()
+      .domain([0, d3.max(bins, (bin) => bin.length) ?? 1])
+      .range([chartHeight, 0])
+      .nice()
+
+    const container = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    container
+      .selectAll('rect')
+      .data(bins)
+      .enter()
+      .append('rect')
+      .attr('x', (d) => xScale(d.x0 ?? domainMin))
+      .attr('y', (d) => yScale(d.length))
+      .attr('width', (d) => Math.max(xScale(d.x1 ?? domainMax) - xScale(d.x0 ?? domainMin) - 4, 0))
+      .attr('height', (d) => chartHeight - yScale(d.length))
+      .attr('fill', '#059669')
+      .attr('rx', 6)
+
+    container
+      .append('g')
+      .attr('transform', `translate(0,${chartHeight})`)
+      .call(d3.axisBottom(xScale).ticks(5))
+
+    container.append('g').call(d3.axisLeft(yScale).ticks(5))
+
+    container
+      .append('text')
+      .attr('x', chartWidth / 2)
+      .attr('y', chartHeight + 28)
+      .attr('text-anchor', 'middle')
+      .attr('fill', '#4b5563')
+      .text('ARPU par plan')
+  }, [metrics])
+
+  useEffect(() => {
+    if (!heatmapRef.current) {
+      return
+    }
+
+    const svg = d3.select(heatmapRef.current)
+    const width = 380
+    const height = 260
+    const margin = { top: 24, right: 16, bottom: 40, left: 140 }
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`)
+    svg.selectAll('*').remove()
+
+    if (cohorts.length === 0) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text('Aucune donnée de cohorte disponible.')
+      return
+    }
+
+    const chartWidth = width - margin.left - margin.right
+    const chartHeight = height - margin.top - margin.bottom
+
+    const periods = Array.from(new Set(cohorts.map((cohort) => cohort.period)))
+    const cohortLabels = Array.from(new Set(cohorts.map((cohort) => `${cohort.cohort} · ${cohort.plan}`)))
+
+    const xScale = d3.scaleBand().domain(periods).range([0, chartWidth]).padding(0.1)
+    const yScale = d3.scaleBand().domain(cohortLabels).range([0, chartHeight]).padding(0.1)
+
+    const colorScale = d3.scaleSequential(d3.interpolateBlues).domain([0.5, 1])
+
+    const container = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    container
+      .selectAll('rect')
+      .data(cohorts)
+      .enter()
+      .append('rect')
+      .attr('x', (d) => xScale(d.period) ?? 0)
+      .attr('y', (d) => yScale(`${d.cohort} · ${d.plan}`) ?? 0)
+      .attr('width', xScale.bandwidth())
+      .attr('height', yScale.bandwidth())
+      .attr('fill', (d) => colorScale(d.retention))
+
+    container
+      .selectAll('text')
+      .data(cohorts)
+      .enter()
+      .append('text')
+      .attr('x', (d) => (xScale(d.period) ?? 0) + xScale.bandwidth() / 2)
+      .attr('y', (d) => (yScale(`${d.cohort} · ${d.plan}`) ?? 0) + yScale.bandwidth() / 2 + 4)
+      .attr('text-anchor', 'middle')
+      .attr('font-size', 10)
+      .attr('fill', '#1f2937')
+      .text((d) => `${Math.round(d.retention * 100)}%`)
+
+    container
+      .append('g')
+      .attr('transform', `translate(0,${chartHeight})`)
+      .call(d3.axisBottom(xScale))
+
+    container.append('g').call(d3.axisLeft(yScale))
+  }, [cohorts])
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="mb-4 flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Abonnements</h2>
+          <p className="text-sm text-slate-500">
+            Distribution ARPU et fidélité par cohorte pour la granularité {granularity}.
+          </p>
+        </div>
+        <div className="text-right text-sm text-slate-600">
+          <div>
+            <span className="font-semibold text-slate-900">{totals.active.toLocaleString('fr-FR')}</span> actifs
+          </div>
+          <div>
+            <span className="font-semibold text-emerald-600">+{totals.newSubs.toLocaleString('fr-FR')}</span> nouveaux
+          </div>
+          <div>
+            <span className="font-semibold text-rose-600">-{totals.churn.toLocaleString('fr-FR')}</span> churn
+          </div>
+          <div>ARPU moyen: €{totals.arpu.toLocaleString('fr-FR')}</div>
+        </div>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div>
+          <h3 className="text-sm font-medium text-slate-700">Histogramme ARPU</h3>
+          <svg ref={histogramRef} className="mt-2 w-full" role="img" aria-label="Histogramme ARPU" />
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-slate-700">Rétention par cohorte</h3>
+          <svg ref={heatmapRef} className="mt-2 w-full" role="img" aria-label="Heatmap cohortes" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/services/financialService.ts
+++ b/src/services/financialService.ts
@@ -1,0 +1,660 @@
+import { format, parseISO } from 'date-fns'
+
+export type TimeGranularity = 'day' | 'week' | 'month'
+export type PlanCode = 'basic' | 'pro' | 'enterprise'
+export type PlanFilter = PlanCode | 'all'
+export type ExportFormat = 'csv' | 'excel' | 'pdf'
+
+export interface FinancialFilters {
+  granularity: TimeGranularity
+  plan: PlanFilter
+  startDate?: string
+  endDate?: string
+  priceVariation?: number
+}
+
+export interface RevenueTrendPoint {
+  period: string
+  revenue: number
+  arpu: number
+  payingUsers: number
+  benefit: number
+}
+
+export interface SubscriptionMetric {
+  plan: PlanCode
+  activeSubscribers: number
+  newSubscriptions: number
+  churnedSubscriptions: number
+  arpu: number
+}
+
+export interface CostCategory {
+  category: string
+  amount: number
+}
+
+export interface CostComparisonPoint {
+  period: string
+  cost: number
+  revenue: number
+}
+
+export interface CostMetrics {
+  categories: CostCategory[]
+  comparison: CostComparisonPoint[]
+}
+
+export interface CohortPoint {
+  cohort: string
+  period: string
+  retention: number
+  plan: PlanCode
+}
+
+export interface BusinessKpi {
+  label: string
+  value: number
+  delta: number
+  format: 'currency' | 'percentage' | 'number'
+}
+
+interface FinancialRecord {
+  date: string
+  plan: PlanCode
+  revenue: number
+  payingUsers: number
+  arpu: number
+  newSubscriptions: number
+  churnedSubscriptions: number
+  marketingSpend: number
+  operationsCost: number
+  infrastructureCost: number
+  supportCost: number
+}
+
+const financialRecords: FinancialRecord[] = [
+  {
+    date: '2024-07-01',
+    plan: 'basic',
+    revenue: 12000,
+    payingUsers: 400,
+    arpu: 30,
+    newSubscriptions: 80,
+    churnedSubscriptions: 20,
+    marketingSpend: 3000,
+    operationsCost: 1500,
+    infrastructureCost: 1200,
+    supportCost: 800
+  },
+  {
+    date: '2024-07-01',
+    plan: 'pro',
+    revenue: 22400,
+    payingUsers: 280,
+    arpu: 80,
+    newSubscriptions: 60,
+    churnedSubscriptions: 15,
+    marketingSpend: 2600,
+    operationsCost: 1400,
+    infrastructureCost: 1100,
+    supportCost: 900
+  },
+  {
+    date: '2024-07-01',
+    plan: 'enterprise',
+    revenue: 30000,
+    payingUsers: 150,
+    arpu: 200,
+    newSubscriptions: 20,
+    churnedSubscriptions: 5,
+    marketingSpend: 4200,
+    operationsCost: 2100,
+    infrastructureCost: 1600,
+    supportCost: 1200
+  },
+  {
+    date: '2024-08-01',
+    plan: 'basic',
+    revenue: 12600,
+    payingUsers: 420,
+    arpu: 30,
+    newSubscriptions: 85,
+    churnedSubscriptions: 18,
+    marketingSpend: 3050,
+    operationsCost: 1520,
+    infrastructureCost: 1200,
+    supportCost: 820
+  },
+  {
+    date: '2024-08-01',
+    plan: 'pro',
+    revenue: 23200,
+    payingUsers: 290,
+    arpu: 80,
+    newSubscriptions: 65,
+    churnedSubscriptions: 14,
+    marketingSpend: 2550,
+    operationsCost: 1350,
+    infrastructureCost: 1100,
+    supportCost: 910
+  },
+  {
+    date: '2024-08-01',
+    plan: 'enterprise',
+    revenue: 31200,
+    payingUsers: 156,
+    arpu: 200,
+    newSubscriptions: 22,
+    churnedSubscriptions: 4,
+    marketingSpend: 4150,
+    operationsCost: 2050,
+    infrastructureCost: 1650,
+    supportCost: 1180
+  },
+  {
+    date: '2024-09-01',
+    plan: 'basic',
+    revenue: 13500,
+    payingUsers: 450,
+    arpu: 30,
+    newSubscriptions: 90,
+    churnedSubscriptions: 17,
+    marketingSpend: 3100,
+    operationsCost: 1580,
+    infrastructureCost: 1250,
+    supportCost: 830
+  },
+  {
+    date: '2024-09-01',
+    plan: 'pro',
+    revenue: 24000,
+    payingUsers: 300,
+    arpu: 80,
+    newSubscriptions: 70,
+    churnedSubscriptions: 13,
+    marketingSpend: 2500,
+    operationsCost: 1380,
+    infrastructureCost: 1120,
+    supportCost: 920
+  },
+  {
+    date: '2024-09-01',
+    plan: 'enterprise',
+    revenue: 32400,
+    payingUsers: 162,
+    arpu: 200,
+    newSubscriptions: 25,
+    churnedSubscriptions: 4,
+    marketingSpend: 4100,
+    operationsCost: 2100,
+    infrastructureCost: 1700,
+    supportCost: 1200
+  }
+]
+
+const cohortRetention: CohortPoint[] = [
+  { cohort: '2024-07', period: 'Month 1', retention: 1, plan: 'basic' },
+  { cohort: '2024-07', period: 'Month 2', retention: 0.82, plan: 'basic' },
+  { cohort: '2024-07', period: 'Month 3', retention: 0.74, plan: 'basic' },
+  { cohort: '2024-07', period: 'Month 1', retention: 1, plan: 'pro' },
+  { cohort: '2024-07', period: 'Month 2', retention: 0.87, plan: 'pro' },
+  { cohort: '2024-07', period: 'Month 3', retention: 0.8, plan: 'pro' },
+  { cohort: '2024-07', period: 'Month 1', retention: 1, plan: 'enterprise' },
+  { cohort: '2024-07', period: 'Month 2', retention: 0.91, plan: 'enterprise' },
+  { cohort: '2024-07', period: 'Month 3', retention: 0.85, plan: 'enterprise' },
+  { cohort: '2024-08', period: 'Month 1', retention: 1, plan: 'basic' },
+  { cohort: '2024-08', period: 'Month 2', retention: 0.83, plan: 'basic' },
+  { cohort: '2024-08', period: 'Month 3', retention: 0.76, plan: 'basic' },
+  { cohort: '2024-08', period: 'Month 1', retention: 1, plan: 'pro' },
+  { cohort: '2024-08', period: 'Month 2', retention: 0.88, plan: 'pro' },
+  { cohort: '2024-08', period: 'Month 3', retention: 0.81, plan: 'pro' },
+  { cohort: '2024-08', period: 'Month 1', retention: 1, plan: 'enterprise' },
+  { cohort: '2024-08', period: 'Month 2', retention: 0.92, plan: 'enterprise' },
+  { cohort: '2024-08', period: 'Month 3', retention: 0.86, plan: 'enterprise' },
+  { cohort: '2024-09', period: 'Month 1', retention: 1, plan: 'basic' },
+  { cohort: '2024-09', period: 'Month 2', retention: 0.84, plan: 'basic' },
+  { cohort: '2024-09', period: 'Month 3', retention: 0.77, plan: 'basic' },
+  { cohort: '2024-09', period: 'Month 1', retention: 1, plan: 'pro' },
+  { cohort: '2024-09', period: 'Month 2', retention: 0.89, plan: 'pro' },
+  { cohort: '2024-09', period: 'Month 3', retention: 0.82, plan: 'pro' },
+  { cohort: '2024-09', period: 'Month 1', retention: 1, plan: 'enterprise' },
+  { cohort: '2024-09', period: 'Month 2', retention: 0.93, plan: 'enterprise' },
+  { cohort: '2024-09', period: 'Month 3', retention: 0.87, plan: 'enterprise' }
+]
+
+const planOptions: PlanCode[] = ['basic', 'pro', 'enterprise']
+
+const getMultiplier = (variation?: number) => 1 + (variation ?? 0) / 100
+
+const getPeriodKey = (date: string, granularity: TimeGranularity) => {
+  const parsed = parseISO(date)
+  if (granularity === 'week') {
+    return format(parsed, 'yyyy-ww')
+  }
+
+  if (granularity === 'month') {
+    return format(parsed, 'yyyy-MM')
+  }
+
+  return format(parsed, 'yyyy-MM-dd')
+}
+
+const sortPeriods = (points: RevenueTrendPoint[]) =>
+  [...points].sort((a, b) => (a.period > b.period ? 1 : -1))
+
+const filterRecords = ({ plan, startDate, endDate }: FinancialFilters) => {
+  return financialRecords.filter((record) => {
+    if (plan !== 'all' && record.plan !== plan) {
+      return false
+    }
+
+    if (startDate && record.date < startDate) {
+      return false
+    }
+
+    if (endDate && record.date > endDate) {
+      return false
+    }
+
+    return true
+  })
+}
+
+const computeCost = (record: FinancialRecord) =>
+  record.marketingSpend +
+  record.operationsCost +
+  record.infrastructureCost +
+  record.supportCost
+
+const formatNumber = (value: number, format: BusinessKpi['format']) => {
+  if (format === 'currency') {
+    return Number(value.toFixed(2))
+  }
+
+  if (format === 'percentage') {
+    return Number((value * 100).toFixed(2))
+  }
+
+  return Number(value.toFixed(2))
+}
+
+const createCsv = (dataset: {
+  revenueTrend: RevenueTrendPoint[]
+  subscriptionMetrics: SubscriptionMetric[]
+  costMetrics: CostMetrics
+  kpis: BusinessKpi[]
+}) => {
+  const revenueRows = ['period,revenue,arpu,payingUsers,benefit']
+  revenueRows.push(
+    ...dataset.revenueTrend.map((point) =>
+      [point.period, point.revenue.toFixed(2), point.arpu.toFixed(2), point.payingUsers, point.benefit.toFixed(2)].join(',')
+    )
+  )
+
+  const subscriptionHeader = '\nplan,activeSubscribers,newSubscriptions,churnedSubscriptions,arpu'
+  const subscriptionRows = dataset.subscriptionMetrics
+    .map((metric) =>
+      [
+        metric.plan,
+        metric.activeSubscribers.toFixed(0),
+        metric.newSubscriptions.toFixed(0),
+        metric.churnedSubscriptions.toFixed(0),
+        metric.arpu.toFixed(2)
+      ].join(',')
+    )
+    .join('\n')
+
+  const costHeader = '\ncategory,amount'
+  const costRows = dataset.costMetrics.categories
+    .map((category) => `${category.category},${category.amount.toFixed(2)}`)
+    .join('\n')
+
+  const kpiHeader = '\nlabel,value,delta,format'
+  const kpiRows = dataset.kpis
+    .map((kpi) => `${kpi.label},${kpi.value.toFixed(2)},${kpi.delta.toFixed(2)},${kpi.format}`)
+    .join('\n')
+
+  return `${revenueRows.join('\n')}${subscriptionHeader}${subscriptionRows}${costHeader}${costRows}${kpiHeader}${kpiRows}`
+}
+
+const createExcel = (dataset: {
+  revenueTrend: RevenueTrendPoint[]
+  subscriptionMetrics: SubscriptionMetric[]
+  costMetrics: CostMetrics
+  kpis: BusinessKpi[]
+}) => {
+  const sections = ['Financial Report']
+  sections.push('Revenue Trend')
+  sections.push('Period\tRevenue\tARPU\tPaying Users\tBenefit')
+  sections.push(
+    ...dataset.revenueTrend.map(
+      (point) =>
+        `${point.period}\t${point.revenue.toFixed(2)}\t${point.arpu.toFixed(2)}\t${point.payingUsers}\t${point.benefit.toFixed(2)}`
+    )
+  )
+
+  sections.push('\nSubscription Metrics')
+  sections.push('Plan\tActive Subscribers\tNew\tChurned\tARPU')
+  sections.push(
+    ...dataset.subscriptionMetrics.map(
+      (metric) =>
+        `${metric.plan}\t${metric.activeSubscribers.toFixed(0)}\t${metric.newSubscriptions.toFixed(0)}\t${metric.churnedSubscriptions.toFixed(0)}\t${metric.arpu.toFixed(2)}`
+    )
+  )
+
+  sections.push('\nCost Breakdown')
+  sections.push('Category\tAmount')
+  sections.push(
+    ...dataset.costMetrics.categories.map((category) => `${category.category}\t${category.amount.toFixed(2)}`)
+  )
+
+  sections.push('\nKey KPIs')
+  sections.push('Label\tValue\tDelta\tFormat')
+  sections.push(
+    ...dataset.kpis.map((kpi) => `${kpi.label}\t${kpi.value.toFixed(2)}\t${kpi.delta.toFixed(2)}\t${kpi.format}`)
+  )
+
+  return sections.join('\n')
+}
+
+const createPdf = (dataset: {
+  revenueTrend: RevenueTrendPoint[]
+  subscriptionMetrics: SubscriptionMetric[]
+  costMetrics: CostMetrics
+  kpis: BusinessKpi[]
+}) => {
+  const lines = ['Financial Report']
+  lines.push('Revenue Trend:')
+  lines.push(
+    ...dataset.revenueTrend.map(
+      (point) =>
+        `${point.period} -> Revenue: ${point.revenue.toFixed(2)}, ARPU: ${point.arpu.toFixed(2)}, Paying Users: ${point.payingUsers}`
+    )
+  )
+  lines.push('\nSubscription Metrics:')
+  lines.push(
+    ...dataset.subscriptionMetrics.map(
+      (metric) =>
+        `${metric.plan} Plan - Active: ${metric.activeSubscribers.toFixed(0)}, New: ${metric.newSubscriptions.toFixed(0)}, Churned: ${metric.churnedSubscriptions.toFixed(0)}, ARPU: ${metric.arpu.toFixed(2)}`
+    )
+  )
+
+  lines.push('\nCost Breakdown:')
+  lines.push(...dataset.costMetrics.categories.map((category) => `${category.category}: ${category.amount.toFixed(2)}`))
+
+  lines.push('\nKPIs:')
+  lines.push(...dataset.kpis.map((kpi) => `${kpi.label}: ${kpi.value.toFixed(2)} (${kpi.delta.toFixed(2)})`))
+
+  return lines.join('\n')
+}
+
+const createBlobWithFallback = (content: string, type: string): Blob => {
+  const blob = new Blob([content], { type })
+  const candidate = blob as Blob & { text?: () => Promise<string> }
+  if (typeof candidate.text !== 'function') {
+    Object.defineProperty(candidate, 'text', {
+      value: async () => content,
+      configurable: true
+    })
+  }
+
+  return blob
+}
+
+const aggregateRevenue = (filters: FinancialFilters): RevenueTrendPoint[] => {
+  const multiplier = getMultiplier(filters.priceVariation)
+  const records = filterRecords(filters)
+  const buckets = new Map<
+    string,
+    {
+      revenue: number
+      payingUsers: number
+      arpuWeighted: number
+      cost: number
+    }
+  >()
+
+  records.forEach((record) => {
+    const key = getPeriodKey(record.date, filters.granularity)
+    const bucket = buckets.get(key) ?? {
+      revenue: 0,
+      payingUsers: 0,
+      arpuWeighted: 0,
+      cost: 0
+    }
+
+    const adjustedRevenue = record.revenue * multiplier
+    const adjustedArpu = record.arpu * multiplier
+
+    bucket.revenue += adjustedRevenue
+    bucket.payingUsers += record.payingUsers
+    bucket.arpuWeighted += adjustedArpu * record.payingUsers
+    bucket.cost += computeCost(record)
+
+    buckets.set(key, bucket)
+  })
+
+  const points = Array.from(buckets.entries()).map(([period, value]) => ({
+    period,
+    revenue: Number(value.revenue.toFixed(2)),
+    arpu: value.payingUsers ? Number((value.arpuWeighted / value.payingUsers).toFixed(2)) : 0,
+    payingUsers: value.payingUsers,
+    benefit: Number((value.revenue - value.cost).toFixed(2))
+  }))
+
+  return sortPeriods(points)
+}
+
+const aggregateSubscriptions = (filters: FinancialFilters): SubscriptionMetric[] => {
+  const multiplier = getMultiplier(filters.priceVariation)
+  const records = filterRecords({ ...filters, plan: 'all' })
+  const buckets = new Map<PlanCode, {
+    payingUsers: number
+    entries: number
+    newSubscriptions: number
+    churnedSubscriptions: number
+    arpuWeighted: number
+  }>()
+
+  records.forEach((record) => {
+    if (filters.plan !== 'all' && record.plan !== filters.plan) {
+      return
+    }
+
+    const bucket = buckets.get(record.plan) ?? {
+      payingUsers: 0,
+      entries: 0,
+      newSubscriptions: 0,
+      churnedSubscriptions: 0,
+      arpuWeighted: 0
+    }
+
+    bucket.payingUsers += record.payingUsers
+    bucket.entries += 1
+    bucket.newSubscriptions += record.newSubscriptions
+    bucket.churnedSubscriptions += record.churnedSubscriptions
+    bucket.arpuWeighted += record.arpu * multiplier * record.payingUsers
+
+    buckets.set(record.plan, bucket)
+  })
+
+  return planOptions
+    .filter((plan) => buckets.has(plan))
+    .map((plan) => {
+      const bucket = buckets.get(plan)!
+      const active = bucket.payingUsers / bucket.entries
+      const arpu = bucket.payingUsers
+        ? Number((bucket.arpuWeighted / bucket.payingUsers).toFixed(2))
+        : 0
+
+      return {
+        plan,
+        activeSubscribers: Number(active.toFixed(0)),
+        newSubscriptions: Number(bucket.newSubscriptions.toFixed(0)),
+        churnedSubscriptions: Number(bucket.churnedSubscriptions.toFixed(0)),
+        arpu
+      }
+    })
+}
+
+const aggregateCosts = (filters: FinancialFilters): CostMetrics => {
+  const multiplier = getMultiplier(filters.priceVariation)
+  const records = filterRecords(filters)
+  const categoryTotals: Record<string, number> = {
+    Marketing: 0,
+    Operations: 0,
+    Infrastructure: 0,
+    Support: 0
+  }
+  const comparisonMap = new Map<string, { cost: number; revenue: number }>()
+
+  records.forEach((record) => {
+    const key = getPeriodKey(record.date, filters.granularity)
+    const cost = computeCost(record)
+    const adjustedRevenue = record.revenue * multiplier
+
+    categoryTotals.Marketing += record.marketingSpend
+    categoryTotals.Operations += record.operationsCost
+    categoryTotals.Infrastructure += record.infrastructureCost
+    categoryTotals.Support += record.supportCost
+
+    const comparison = comparisonMap.get(key) ?? { cost: 0, revenue: 0 }
+    comparison.cost += cost
+    comparison.revenue += adjustedRevenue
+    comparisonMap.set(key, comparison)
+  })
+
+  return {
+    categories: Object.entries(categoryTotals).map(([category, amount]) => ({
+      category,
+      amount: Number(amount.toFixed(2))
+    })),
+    comparison: sortPeriods(
+      Array.from(comparisonMap.entries()).map(([period, values]) => ({
+        period,
+        cost: Number(values.cost.toFixed(2)),
+        revenue: Number(values.revenue.toFixed(2))
+      }))
+    )
+  }
+}
+
+const aggregateKpis = (filters: FinancialFilters): BusinessKpi[] => {
+  const revenueTrend = aggregateRevenue(filters)
+  const costMetrics = aggregateCosts(filters)
+  const subscriptions = aggregateSubscriptions(filters)
+
+  const totalRevenue = revenueTrend.reduce((sum, point) => sum + point.revenue, 0)
+  const totalCost = costMetrics.comparison.reduce((sum, point) => sum + point.cost, 0)
+  const totalPayingUsers = revenueTrend.reduce((sum, point) => sum + point.payingUsers, 0)
+  const totalNewSubscriptions = subscriptions.reduce((sum, metric) => sum + metric.newSubscriptions, 0)
+  const totalChurned = subscriptions.reduce((sum, metric) => sum + metric.churnedSubscriptions, 0)
+
+  const lastPeriod = revenueTrend[revenueTrend.length - 1]
+  const previousPeriod = revenueTrend[revenueTrend.length - 2]
+
+  const mrr = lastPeriod ? lastPeriod.revenue : 0
+  const arr = mrr * 12
+
+  const averageArpu = totalPayingUsers
+    ? Number((totalRevenue / totalPayingUsers).toFixed(2))
+    : 0
+
+  const churnRate = totalPayingUsers
+    ? Number((totalChurned / (totalChurned + totalPayingUsers)).toFixed(4))
+    : 0
+
+  const grossMargin = totalRevenue
+    ? Number(((totalRevenue - totalCost) / totalRevenue).toFixed(4))
+    : 0
+
+  const ltv = churnRate > 0 ? Number(((averageArpu * grossMargin) / churnRate).toFixed(2)) : 0
+
+  const cac = totalNewSubscriptions > 0 ? Number((totalCost / totalNewSubscriptions).toFixed(2)) : 0
+
+  const costPerUser = totalPayingUsers > 0 ? totalCost / totalPayingUsers : 0
+  const netContribution = averageArpu - costPerUser
+  const paybackPeriod = netContribution > 0 && cac > 0 ? Number((cac / netContribution).toFixed(2)) : 0
+
+  const revenueDelta = previousPeriod ? Number((lastPeriod.revenue - previousPeriod.revenue).toFixed(2)) : 0
+
+  return [
+    { label: 'MRR', value: formatNumber(mrr, 'currency'), delta: revenueDelta, format: 'currency' },
+    { label: 'ARR', value: formatNumber(arr, 'currency'), delta: revenueDelta * 12, format: 'currency' },
+    { label: 'ARPU', value: formatNumber(averageArpu, 'currency'), delta: 0, format: 'currency' },
+    { label: 'Churn Rate', value: formatNumber(churnRate, 'percentage'), delta: 0, format: 'percentage' },
+    { label: 'LTV', value: formatNumber(ltv, 'currency'), delta: 0, format: 'currency' },
+    { label: 'CAC', value: formatNumber(cac, 'currency'), delta: 0, format: 'currency' },
+    { label: 'Payback Period (months)', value: formatNumber(paybackPeriod, 'number'), delta: 0, format: 'number' },
+    { label: 'Gross Margin', value: formatNumber(grossMargin, 'percentage'), delta: 0, format: 'percentage' }
+  ]
+}
+
+const filterCohorts = (filters: FinancialFilters): CohortPoint[] => {
+  return cohortRetention.filter((point) => {
+    if (filters.plan !== 'all' && point.plan !== filters.plan) {
+      return false
+    }
+
+    if (filters.startDate && `${point.cohort}-01` < filters.startDate) {
+      return false
+    }
+
+    if (filters.endDate && `${point.cohort}-01` > filters.endDate) {
+      return false
+    }
+
+    return true
+  })
+}
+
+const getExportPayload = async (filters: FinancialFilters) => {
+  const [revenueTrend, subscriptionMetrics, costMetrics, kpis] = await Promise.all([
+    FinancialService.getRevenueTrend(filters),
+    FinancialService.getSubscriptionMetrics(filters),
+    FinancialService.getCostMetrics(filters),
+    FinancialService.getBusinessKpis(filters)
+  ])
+
+  return { revenueTrend, subscriptionMetrics, costMetrics, kpis }
+}
+
+export const FinancialService = {
+  getPlanOptions(): PlanCode[] {
+    return [...planOptions]
+  },
+  async getRevenueTrend(filters: FinancialFilters): Promise<RevenueTrendPoint[]> {
+    return aggregateRevenue(filters)
+  },
+  async getSubscriptionMetrics(filters: FinancialFilters): Promise<SubscriptionMetric[]> {
+    return aggregateSubscriptions(filters)
+  },
+  async getCostMetrics(filters: FinancialFilters): Promise<CostMetrics> {
+    return aggregateCosts(filters)
+  },
+  async getBusinessKpis(filters: FinancialFilters): Promise<BusinessKpi[]> {
+    return aggregateKpis(filters)
+  },
+  async getCohortRetention(filters: FinancialFilters): Promise<CohortPoint[]> {
+    return filterCohorts(filters)
+  },
+  async exportFinancialData(format: ExportFormat, filters: FinancialFilters): Promise<Blob> {
+    const payload = await getExportPayload(filters)
+
+    if (format === 'csv') {
+      const csv = createCsv(payload)
+      return createBlobWithFallback(csv, 'text/csv')
+    }
+
+    if (format === 'excel') {
+      const excel = createExcel(payload)
+      return createBlobWithFallback(excel, 'application/vnd.ms-excel')
+    }
+
+    const pdf = createPdf(payload)
+    return createBlobWithFallback(pdf, 'application/pdf')
+  }
+}
+
+export type { FinancialRecord }


### PR DESCRIPTION
## Summary
- implement a financial analytics service to aggregate revenue, subscription, cohort, and KPI data and build export payloads
- add a finance dashboard with D3-driven revenue, subscription, and cost visualisations plus export controls and price simulation
- cover the aggregation and export logic with focused Vitest coverage

## Testing
- npx vitest run src/__tests__/financialDashboard.test.tsx --environment jsdom


------
https://chatgpt.com/codex/tasks/task_e_68d9db263b60833286760868e120d274