### PR TITLE
Add security center module with GDPR workflows and audit tooling

### DIFF
--- a/src/__tests__/securityCenter.test.tsx
+++ b/src/__tests__/securityCenter.test.tsx
@@ -1,0 +1,267 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import * as matchers from '@testing-library/jest-dom/matchers'
+import React, { ComponentType } from 'react'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SecurityService } from '../services/securityService'
+import { downloadCsv } from '../utils/csv'
+
+const permissionsState = {
+  admin: { id: 'admin-1', email: 'admin@example.com', name: 'Security Admin' },
+  permissions: [] as string[],
+  roles: [] as string[],
+  isLoading: false,
+  error: null as string | null,
+  hasPermissions(required?: string[]) {
+    if (!required || required.length === 0) {
+      return true
+    }
+    return required.every(permission => permissionsState.permissions.includes(permission))
+  }
+}
+
+vi.mock('../hooks/usePermissions', () => ({
+  __esModule: true,
+  usePermissions: () => permissionsState
+}))
+
+vi.mock('../services/securityService', () => {
+  const service = {
+    listAuditLogs: vi.fn(),
+    exportAuditLogs: vi.fn(),
+    listGdprRequests: vi.fn(),
+    updateGdprRequestStatus: vi.fn(),
+    confirmGdprAction: vi.fn(),
+    downloadGdprArchive: vi.fn(),
+    listIncidentPlaybooks: vi.fn(),
+    logIncidentAction: vi.fn(),
+    listComplianceReports: vi.fn(),
+    downloadComplianceReport: vi.fn()
+  }
+
+  return {
+    SecurityService: service,
+    AUDIT_SEVERITY_LABELS: {
+      low: 'Faible',
+      medium: 'Modérée',
+      high: 'Élevée',
+      critical: 'Critique'
+    },
+    GDPR_STATUS_LABELS: {
+      received: 'Reçue',
+      in_progress: 'En cours',
+      awaiting_confirmation: 'En attente de confirmation',
+      completed: 'Terminée',
+      rejected: 'Rejetée'
+    }
+  }
+})
+
+vi.mock('../utils/csv', () => ({
+  downloadCsv: vi.fn()
+}))
+
+expect.extend(matchers)
+
+describe('Security center module', () => {
+  const mockedSecurityService = vi.mocked(SecurityService, true)
+  const mockedDownloadCsv = vi.mocked(downloadCsv, true)
+
+  const now = new Date().toISOString()
+  const auditLog = {
+    id: 'audit-1',
+    timestamp: now,
+    actor: 'admin@example.com',
+    action: 'Updated configuration',
+    resourceType: 'configuration',
+    severity: 'high' as const,
+    ipAddress: '192.168.1.10'
+  }
+  const gdprRequest = {
+    id: 'gdpr-1',
+    userId: 'user-1',
+    userEmail: 'user@example.com',
+    type: 'erasure' as const,
+    submittedAt: now,
+    status: 'received' as const,
+    assignedTo: 'analyst-1',
+    dueAt: now
+  }
+  const incidentPlaybook = {
+    id: 'incident-1',
+    name: 'Credential stuffing response',
+    description: 'Steps to respond to automated credential stuffing.',
+    severity: 'critical' as const,
+    category: 'availability' as const,
+    steps: [
+      {
+        id: 'step-1',
+        title: 'Activate WAF rules',
+        description: 'Enable rate limiting and IP blocking.'
+      }
+    ],
+    actionLog: []
+  }
+  const complianceReport = {
+    id: 'report-1',
+    name: 'SOC2 Type II 2024',
+    period: 'FY2024',
+    generatedAt: now,
+    status: 'available',
+    format: 'pdf'
+  }
+
+  let SecurityCenterComponent: ComponentType
+  let originalCreateObjectURL: typeof URL.createObjectURL | undefined
+  let originalRevokeObjectURL: typeof URL.revokeObjectURL | undefined
+
+  beforeAll(async () => {
+    SecurityCenterComponent = (await import('../components/security/SecurityCenter')).SecurityCenter
+
+    originalCreateObjectURL = URL.createObjectURL
+    originalRevokeObjectURL = URL.revokeObjectURL
+
+    URL.createObjectURL = vi.fn(() => 'blob:mock')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterAll(() => {
+    if (originalCreateObjectURL) {
+      URL.createObjectURL = originalCreateObjectURL
+    } else {
+      delete (URL as unknown as { createObjectURL?: typeof URL.createObjectURL }).createObjectURL
+    }
+
+    if (originalRevokeObjectURL) {
+      URL.revokeObjectURL = originalRevokeObjectURL
+    } else {
+      delete (URL as unknown as { revokeObjectURL?: typeof URL.revokeObjectURL }).revokeObjectURL
+    }
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    permissionsState.permissions = ['admin:access', 'security:read', 'security:manage', 'security:export']
+    permissionsState.roles = ['super-admin']
+    permissionsState.error = null
+
+    mockedSecurityService.listAuditLogs.mockResolvedValue({ logs: [auditLog], total: 1 })
+    mockedSecurityService.exportAuditLogs.mockResolvedValue(new Blob())
+    mockedSecurityService.listGdprRequests.mockResolvedValue({ requests: [gdprRequest], total: 1 })
+    mockedSecurityService.updateGdprRequestStatus.mockImplementation(async (_, payload) => ({
+      ...gdprRequest,
+      status: payload.status
+    }))
+    mockedSecurityService.confirmGdprAction.mockImplementation(async () => ({
+      ...gdprRequest,
+      status: 'completed' as const
+    }))
+    mockedSecurityService.downloadGdprArchive.mockResolvedValue(new Blob())
+    mockedSecurityService.listIncidentPlaybooks.mockResolvedValue({ playbooks: [incidentPlaybook] })
+    mockedSecurityService.logIncidentAction.mockResolvedValue({
+      id: 'log-1',
+      stepId: 'step-1',
+      actor: 'admin@example.com',
+      note: 'WAF enabled',
+      timestamp: now,
+      status: 'completed'
+    })
+    mockedSecurityService.listComplianceReports.mockResolvedValue({ reports: [complianceReport] })
+    mockedSecurityService.downloadComplianceReport.mockResolvedValue(new Blob())
+  })
+
+  function renderSecurityCenter() {
+    const Component = SecurityCenterComponent
+    return render(<Component />)
+  }
+
+  it('enforces permission boundaries on GDPR workflows', async () => {
+    permissionsState.permissions = ['admin:access', 'security:read']
+    permissionsState.roles = ['security-analyst']
+
+    renderSecurityCenter()
+
+    await waitFor(() => expect(mockedSecurityService.listAuditLogs).toHaveBeenCalled())
+
+    fireEvent.click(await screen.findByTestId('tab-gdpr'))
+
+    const startButton = await screen.findByTestId('gdpr-action-start-gdpr-1')
+    expect(startButton).toBeDisabled()
+
+    const downloadButton = screen.getByTestId('gdpr-action-download-gdpr-1')
+    expect(downloadButton).toBeDisabled()
+  })
+
+  it('exports audit logs with the active filters applied', async () => {
+    permissionsState.permissions = ['admin:access', 'security:read', 'security:export']
+    permissionsState.roles = ['auditor']
+
+    renderSecurityCenter()
+
+    await waitFor(() => expect(mockedSecurityService.listAuditLogs).toHaveBeenCalled())
+
+    const searchInput = await screen.findByTestId('audit-search')
+    fireEvent.change(searchInput, { target: { value: 'configuration' } })
+
+    const exportCsvButton = screen.getByTestId('audit-export-csv')
+    fireEvent.click(exportCsvButton)
+
+    await waitFor(() =>
+      expect(mockedSecurityService.exportAuditLogs).toHaveBeenCalledWith(
+        'csv',
+        expect.objectContaining({ search: 'configuration' })
+      )
+    )
+
+    expect(mockedDownloadCsv).toHaveBeenCalled()
+  })
+
+  it('drives GDPR status transitions and confirmations', async () => {
+    renderSecurityCenter()
+
+    await waitFor(() => expect(mockedSecurityService.listAuditLogs).toHaveBeenCalled())
+
+    fireEvent.click(await screen.findByTestId('tab-gdpr'))
+
+    const startButton = await screen.findByTestId('gdpr-action-start-gdpr-1')
+    fireEvent.click(startButton)
+
+    await waitFor(() =>
+      expect(mockedSecurityService.updateGdprRequestStatus).toHaveBeenCalledWith('gdpr-1', {
+        status: 'in_progress',
+        assigneeId: 'admin-1',
+        note: expect.stringContaining('in_progress')
+      })
+    )
+
+    await waitFor(() => expect(screen.getByText('En cours')).toBeInTheDocument())
+
+    const awaitingButton = await screen.findByTestId('gdpr-action-awaiting-gdpr-1')
+    fireEvent.click(awaitingButton)
+
+    await waitFor(() =>
+      expect(mockedSecurityService.updateGdprRequestStatus).toHaveBeenCalledWith('gdpr-1', {
+        status: 'awaiting_confirmation',
+        assigneeId: 'admin-1',
+        note: expect.stringContaining('awaiting_confirmation')
+      })
+    )
+
+    const confirmButton = await screen.findByTestId('gdpr-action-confirm-gdpr-1')
+    fireEvent.click(confirmButton)
+
+    await waitFor(() =>
+      expect(mockedSecurityService.confirmGdprAction).toHaveBeenCalledWith('gdpr-1', {
+        confirmationMessage: 'GDPR request completed',
+        confirmedBy: 'admin-1'
+      })
+    )
+
+    await waitFor(() => expect(screen.getByText('Terminée')).toBeInTheDocument())
+
+    const downloadButton = screen.getByTestId('gdpr-action-download-gdpr-1')
+    fireEvent.click(downloadButton)
+
+    await waitFor(() => expect(mockedSecurityService.downloadGdprArchive).toHaveBeenCalledWith('gdpr-1'))
+  })
+})

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,7 @@ import { AdminLayout } from './components/layout/AdminLayout'
 import { ADMIN_MODULES } from './utils/adminNavigation'
 import { ModerationDashboard } from './components/moderation/ModerationDashboard'
 import { PlatformSettings } from './components/configuration/PlatformSettings'
+import { SecurityCenter } from './components/security/SecurityCenter'
 
 interface RequirePermissionsProps {
   requiredPermissions?: string[]
@@ -94,6 +95,8 @@ export default function App() {
                       <EventManagement />
                     ) : module.path === 'moderation' ? (
                       <ModerationDashboard />
+                    ) : module.path === 'security' ? (
+                      <SecurityCenter />
                     ) : module.path === 'configuration' ? (
                       <PlatformSettings />
                     ) : (

--- a/src/components/security/SecurityCenter.tsx
+++ b/src/components/security/SecurityCenter.tsx
@@ -1,0 +1,665 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AUDIT_SEVERITY_LABELS,
+  AuditLogEntry,
+  AuditLogQuery,
+  AuditSeverity,
+  GDPR_STATUS_LABELS,
+  GdprRequest,
+  IncidentActionLog,
+  IncidentPlaybook,
+  SecurityService
+} from '../../services/securityService'
+import { usePagination } from '../../hooks/usePagination'
+import { useDebounce } from '../../hooks/useDebounce'
+import { downloadCsv } from '../../utils/csv'
+import { usePermissions } from '../../hooks/usePermissions'
+
+const tabs = [
+  { id: 'audit', label: 'Audit Logs' },
+  { id: 'gdpr', label: 'GDPR Requests' },
+  { id: 'incidents', label: 'Incident Response' },
+  { id: 'compliance', label: 'Compliance Reports' }
+] as const
+
+type TabId = (typeof tabs)[number]['id']
+
+type AuditSeverityFilter = AuditSeverity | 'all'
+
+interface AuditFiltersState {
+  search: string
+  actor: string
+  resource: string
+  severity: AuditSeverityFilter
+}
+
+const auditResourceOptions = [
+  { value: 'all', label: 'All modules' },
+  { value: 'authentication', label: 'Authentication' },
+  { value: 'users', label: 'Users' },
+  { value: 'events', label: 'Events' },
+  { value: 'security', label: 'Security' },
+  { value: 'compliance', label: 'Compliance' }
+]
+
+const auditSeverityOptions: { value: AuditSeverityFilter; label: string }[] = [
+  { value: 'all', label: 'All severities' },
+  ...Object.entries(AUDIT_SEVERITY_LABELS).map(([value, label]) => ({
+    value: value as AuditSeverity,
+    label
+  }))
+]
+
+type IncidentNoteState = Record<string, string>
+
+type IncidentLogState = Record<string, IncidentActionLog[]>
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+function formatDate(timestamp: string) {
+  return new Date(timestamp).toLocaleString()
+}
+
+export function SecurityCenter() {
+  const [activeTab, setActiveTab] = useState<TabId>('audit')
+  const [auditLogs, setAuditLogs] = useState<AuditLogEntry[]>([])
+  const [auditTotal, setAuditTotal] = useState(0)
+  const [auditError, setAuditError] = useState<string | null>(null)
+  const [isAuditLoading, setIsAuditLoading] = useState(false)
+  const [auditFilters, setAuditFilters] = useState<AuditFiltersState>({
+    search: '',
+    actor: '',
+    resource: 'all',
+    severity: 'all'
+  })
+
+  const [gdprRequests, setGdprRequests] = useState<GdprRequest[]>([])
+  const [isGdprLoading, setIsGdprLoading] = useState(false)
+  const [gdprError, setGdprError] = useState<string | null>(null)
+
+  const [incidentPlaybooks, setIncidentPlaybooks] = useState<IncidentPlaybook[]>([])
+  const [incidentNotes, setIncidentNotes] = useState<IncidentNoteState>({})
+  const [incidentLogs, setIncidentLogs] = useState<IncidentLogState>({})
+  const [incidentError, setIncidentError] = useState<string | null>(null)
+
+  const [complianceReports, setComplianceReports] = useState<
+    { id: string; name: string; period: string; generatedAt: string; status: string; format: string }[]
+  >([])
+  const [complianceError, setComplianceError] = useState<string | null>(null)
+
+  const { admin, hasPermissions } = usePermissions()
+  const canManageSecurity = hasPermissions(['security:manage'])
+  const canExportAudit = hasPermissions(['security:export']) || canManageSecurity
+
+  const { page, pageSize, setPage } = usePagination(25)
+  const debouncedSearch = useDebounce(auditFilters.search, 250)
+
+  const normalizedAuditFilters = useMemo<AuditLogQuery>(
+    () => ({
+      search: debouncedSearch || undefined,
+      actor: auditFilters.actor.trim() || undefined,
+      resourceType: auditFilters.resource === 'all' ? undefined : auditFilters.resource,
+      severity: auditFilters.severity === 'all' ? undefined : auditFilters.severity,
+      page,
+      pageSize,
+      sort: '-timestamp'
+    }),
+    [auditFilters, debouncedSearch, page, pageSize]
+  )
+
+  const loadAuditLogs = useCallback(async () => {
+    setIsAuditLoading(true)
+    setAuditError(null)
+
+    try {
+      const { logs, total } = await SecurityService.listAuditLogs(normalizedAuditFilters)
+      setAuditLogs(logs)
+      setAuditTotal(total)
+    } catch (error) {
+      console.error('Failed to load audit logs', error)
+      setAuditError('Unable to load audit logs. Please try again later.')
+    } finally {
+      setIsAuditLoading(false)
+    }
+  }, [normalizedAuditFilters])
+
+  const loadGdprRequests = useCallback(async () => {
+    setIsGdprLoading(true)
+    setGdprError(null)
+
+    try {
+      const { requests } = await SecurityService.listGdprRequests()
+      setGdprRequests(requests)
+    } catch (error) {
+      console.error('Failed to load GDPR requests', error)
+      setGdprError('Unable to load GDPR requests at the moment.')
+    } finally {
+      setIsGdprLoading(false)
+    }
+  }, [])
+
+  const loadPlaybooks = useCallback(async () => {
+    setIncidentError(null)
+
+    try {
+      const { playbooks } = await SecurityService.listIncidentPlaybooks()
+      setIncidentPlaybooks(playbooks)
+      setIncidentLogs(
+        playbooks.reduce<IncidentLogState>((acc, playbook) => {
+          acc[playbook.id] = playbook.actionLog || []
+          return acc
+        }, {})
+      )
+    } catch (error) {
+      console.error('Failed to load incident playbooks', error)
+      setIncidentError('Unable to load incident response playbooks.')
+    }
+  }, [])
+
+  const loadComplianceReports = useCallback(async () => {
+    setComplianceError(null)
+
+    try {
+      const { reports } = await SecurityService.listComplianceReports()
+      setComplianceReports(reports)
+    } catch (error) {
+      console.error('Failed to load compliance reports', error)
+      setComplianceError('Unable to load compliance reports.')
+    }
+  }, [])
+
+  useEffect(() => {
+    loadAuditLogs()
+  }, [loadAuditLogs])
+
+  useEffect(() => {
+    loadGdprRequests()
+    loadPlaybooks()
+    loadComplianceReports()
+  }, [loadGdprRequests, loadPlaybooks, loadComplianceReports])
+
+  const handleAuditFilterChange = (changes: Partial<AuditFiltersState>) => {
+    setAuditFilters(prev => ({ ...prev, ...changes }))
+    setPage(0)
+  }
+
+  const handleAuditExport = async (format: 'csv' | 'json') => {
+    if (!canExportAudit) {
+      return
+    }
+
+    try {
+      const exportFilters: AuditLogQuery = {
+        ...normalizedAuditFilters,
+        search: auditFilters.search || undefined,
+        actor: auditFilters.actor.trim() || undefined,
+        resourceType: auditFilters.resource === 'all' ? undefined : auditFilters.resource,
+        severity: auditFilters.severity === 'all' ? undefined : auditFilters.severity
+      }
+
+      const blob = await SecurityService.exportAuditLogs(format, exportFilters)
+      if (format === 'csv') {
+        downloadCsv(blob, `audit-logs.${format}`)
+      } else {
+        downloadBlob(blob, `audit-logs.${format}`)
+      }
+    } catch (error) {
+      console.error('Failed to export audit logs', error)
+      setAuditError('Export failed. Please retry later.')
+    }
+  }
+
+  const updateGdprRequestLocally = (updated: GdprRequest) => {
+    setGdprRequests(prev => prev.map(request => (request.id === updated.id ? updated : request)))
+  }
+
+  const handleGdprTransition = async (request: GdprRequest, status: GdprRequest['status']) => {
+    if (!canManageSecurity) {
+      return
+    }
+
+    try {
+      const updated = await SecurityService.updateGdprRequestStatus(request.id, {
+        status,
+        assigneeId: admin?.id,
+        note: `Status changed to ${status}`
+      })
+      updateGdprRequestLocally(updated)
+    } catch (error) {
+      console.error('Failed to update GDPR request', error)
+      setGdprError('Unable to update the GDPR request status.')
+    }
+  }
+
+  const handleGdprConfirm = async (request: GdprRequest) => {
+    if (!canManageSecurity) {
+      return
+    }
+
+    try {
+      const updated = await SecurityService.confirmGdprAction(request.id, {
+        confirmationMessage: 'GDPR request completed',
+        confirmedBy: admin?.id
+      })
+      updateGdprRequestLocally(updated)
+    } catch (error) {
+      console.error('Failed to confirm GDPR action', error)
+      setGdprError('Unable to confirm the GDPR request completion.')
+    }
+  }
+
+  const handleGdprArchiveDownload = async (request: GdprRequest) => {
+    if (!canManageSecurity && !hasPermissions(['security:read'])) {
+      return
+    }
+
+    try {
+      const blob = await SecurityService.downloadGdprArchive(request.id)
+      downloadBlob(blob, `gdpr-request-${request.id}.zip`)
+    } catch (error) {
+      console.error('Failed to download GDPR archive', error)
+      setGdprError('Unable to download the GDPR archive.')
+    }
+  }
+
+  const handleIncidentNoteChange = (stepKey: string, note: string) => {
+    setIncidentNotes(prev => ({ ...prev, [stepKey]: note }))
+  }
+
+  const handleLogIncidentAction = async (playbook: IncidentPlaybook, stepId: string) => {
+    if (!canManageSecurity) {
+      return
+    }
+
+    const stepKey = `${playbook.id}-${stepId}`
+
+    try {
+      const logEntry = await SecurityService.logIncidentAction(playbook.id, {
+        stepId,
+        note: incidentNotes[stepKey],
+        status: 'completed'
+      })
+
+      setIncidentLogs(prev => ({
+        ...prev,
+        [playbook.id]: [...(prev[playbook.id] || []), logEntry]
+      }))
+
+      setIncidentNotes(prev => ({ ...prev, [stepKey]: '' }))
+    } catch (error) {
+      console.error('Failed to log incident action', error)
+      setIncidentError('Unable to log the incident response step.')
+    }
+  }
+
+  const handleComplianceDownload = async (reportId: string, format: string) => {
+    try {
+      const blob = await SecurityService.downloadComplianceReport(reportId)
+      downloadBlob(blob, `compliance-report-${reportId}.${format}`)
+    } catch (error) {
+      console.error('Failed to download compliance report', error)
+      setComplianceError('Unable to download the compliance report.')
+    }
+  }
+
+  const renderAuditTab = () => (
+    <section aria-labelledby="security-tab-audit">
+      <header className="security-section-header">
+        <div>
+          <h2 id="security-tab-audit">Audit trail overview</h2>
+          <p>Monitor admin activity across the platform with advanced filtering and exports.</p>
+        </div>
+        <div className="security-actions">
+          <button
+            type="button"
+            onClick={() => handleAuditExport('json')}
+            disabled={!canExportAudit}
+            data-testid="audit-export-json"
+          >
+            Export JSON
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAuditExport('csv')}
+            disabled={!canExportAudit}
+            data-testid="audit-export-csv"
+          >
+            Export CSV
+          </button>
+        </div>
+      </header>
+
+      <div className="security-filters">
+        <input
+          type="search"
+          placeholder="Full-text search (user, action, resource, IP...)"
+          value={auditFilters.search}
+          onChange={event => handleAuditFilterChange({ search: event.target.value })}
+          data-testid="audit-search"
+        />
+        <input
+          type="text"
+          placeholder="Actor"
+          value={auditFilters.actor}
+          onChange={event => handleAuditFilterChange({ actor: event.target.value })}
+          data-testid="audit-filter-actor"
+        />
+        <select
+          value={auditFilters.resource}
+          onChange={event => handleAuditFilterChange({ resource: event.target.value })}
+          data-testid="audit-filter-resource"
+        >
+          {auditResourceOptions.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={auditFilters.severity}
+          onChange={event =>
+            handleAuditFilterChange({ severity: event.target.value as AuditSeverityFilter })
+          }
+          data-testid="audit-filter-severity"
+        >
+          {auditSeverityOptions.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {auditError && (
+        <div role="alert" className="security-error">
+          {auditError}
+        </div>
+      )}
+
+      <div className="security-table" role="table">
+        <div className="security-table__header" role="row">
+          <div role="columnheader">Timestamp</div>
+          <div role="columnheader">Actor</div>
+          <div role="columnheader">Action</div>
+          <div role="columnheader">Resource</div>
+          <div role="columnheader">Severity</div>
+          <div role="columnheader">IP address</div>
+        </div>
+        {isAuditLoading ? (
+          <div className="security-table__empty" role="row">
+            Loading audit logs...
+          </div>
+        ) : auditLogs.length === 0 ? (
+          <div className="security-table__empty" role="row">
+            No audit activity for the selected filters.
+          </div>
+        ) : (
+          auditLogs.map(log => (
+            <div
+              key={log.id}
+              role="row"
+              className="security-table__row"
+              data-testid={`audit-row-${log.id}`}
+            >
+              <div role="cell">{formatDate(log.timestamp)}</div>
+              <div role="cell">{log.actor}</div>
+              <div role="cell">{log.action}</div>
+              <div role="cell">{log.resourceType || 'N/A'}</div>
+              <div role="cell">{AUDIT_SEVERITY_LABELS[log.severity]}</div>
+              <div role="cell">{log.ipAddress || '—'}</div>
+            </div>
+          ))
+        )}
+      </div>
+      <footer className="security-footer">
+        <span>
+          Showing {auditLogs.length} of {auditTotal} entries
+        </span>
+      </footer>
+    </section>
+  )
+
+  const renderGdprTab = () => (
+    <section aria-labelledby="security-tab-gdpr">
+      <header className="security-section-header">
+        <div>
+          <h2 id="security-tab-gdpr">GDPR fulfillment workflow</h2>
+          <p>Track incoming privacy requests, collect confirmations and store proof of delivery.</p>
+        </div>
+      </header>
+
+      {gdprError && (
+        <div role="alert" className="security-error">
+          {gdprError}
+        </div>
+      )}
+
+      {isGdprLoading ? (
+        <p>Loading GDPR requests...</p>
+      ) : gdprRequests.length === 0 ? (
+        <p>No GDPR requests pending review.</p>
+      ) : (
+        <div className="security-list">
+          {gdprRequests.map(request => (
+            <article key={request.id} className="security-card" data-testid={`gdpr-card-${request.id}`}>
+              <header>
+                <h3>{request.userEmail}</h3>
+                <p>
+                  {request.type} • Submitted on {formatDate(request.submittedAt)}
+                </p>
+              </header>
+              <dl className="security-card__meta">
+                <div>
+                  <dt>Status</dt>
+                  <dd>{GDPR_STATUS_LABELS[request.status]}</dd>
+                </div>
+                {request.assignedTo && (
+                  <div>
+                    <dt>Assignee</dt>
+                    <dd>{request.assignedTo}</dd>
+                  </div>
+                )}
+                {request.dueAt && (
+                  <div>
+                    <dt>Due</dt>
+                    <dd>{formatDate(request.dueAt)}</dd>
+                  </div>
+                )}
+              </dl>
+              <div className="security-card__actions">
+                <button
+                  type="button"
+                  onClick={() => handleGdprTransition(request, 'in_progress')}
+                  disabled={!canManageSecurity}
+                  data-testid={`gdpr-action-start-${request.id}`}
+                >
+                  Start processing
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleGdprTransition(request, 'awaiting_confirmation')}
+                  disabled={!canManageSecurity || request.status !== 'in_progress'}
+                  data-testid={`gdpr-action-awaiting-${request.id}`}
+                >
+                  Await confirmation
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleGdprConfirm(request)}
+                  disabled={!canManageSecurity || request.status !== 'awaiting_confirmation'}
+                  data-testid={`gdpr-action-confirm-${request.id}`}
+                >
+                  Confirm closure
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleGdprArchiveDownload(request)}
+                  data-testid={`gdpr-action-download-${request.id}`}
+                  disabled={!canManageSecurity && !hasPermissions(['security:export'])}
+                >
+                  Download archive
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+
+  const renderIncidentTab = () => (
+    <section aria-labelledby="security-tab-incidents">
+      <header className="security-section-header">
+        <div>
+          <h2 id="security-tab-incidents">Incident response playbooks</h2>
+          <p>Follow predefined playbooks and keep a detailed log of mitigation steps.</p>
+        </div>
+      </header>
+
+      {incidentError && (
+        <div role="alert" className="security-error">
+          {incidentError}
+        </div>
+      )}
+
+      {incidentPlaybooks.length === 0 ? (
+        <p>No incident playbooks configured.</p>
+      ) : (
+        <div className="security-list">
+          {incidentPlaybooks.map(playbook => (
+            <article key={playbook.id} className="security-card" data-testid={`incident-card-${playbook.id}`}>
+              <header>
+                <h3>{playbook.name}</h3>
+                <p>
+                  {playbook.category} • Severity {AUDIT_SEVERITY_LABELS[playbook.severity]}
+                </p>
+              </header>
+              <ol className="security-steps">
+                {playbook.steps.map(step => {
+                  const stepKey = `${playbook.id}-${step.id}`
+                  return (
+                    <li key={step.id} className="security-steps__item">
+                      <div>
+                        <strong>{step.title}</strong>
+                        {step.description && <p>{step.description}</p>}
+                      </div>
+                      <textarea
+                        value={incidentNotes[stepKey] || ''}
+                        onChange={event => handleIncidentNoteChange(stepKey, event.target.value)}
+                        placeholder="Add response notes"
+                        rows={2}
+                        data-testid={`incident-note-${stepKey}`}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => handleLogIncidentAction(playbook, step.id)}
+                        disabled={!canManageSecurity}
+                        data-testid={`incident-log-${stepKey}`}
+                      >
+                        Log action
+                      </button>
+                    </li>
+                  )
+                })}
+              </ol>
+              <section className="security-log" aria-label="Action log">
+                <h4>Action log</h4>
+                {(incidentLogs[playbook.id] || []).length === 0 ? (
+                  <p>No actions logged yet.</p>
+                ) : (
+                  <ul>
+                    {(incidentLogs[playbook.id] || []).map(log => (
+                      <li key={log.id}>
+                        <span>{formatDate(log.timestamp)}</span> — <span>{log.actor}</span>
+                        {log.note && <span>: {log.note}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+
+  const renderComplianceTab = () => (
+    <section aria-labelledby="security-tab-compliance">
+      <header className="security-section-header">
+        <div>
+          <h2 id="security-tab-compliance">Compliance reporting</h2>
+          <p>Centralize SOC2, ISO and GDPR evidence packages for audits.</p>
+        </div>
+      </header>
+
+      {complianceError && (
+        <div role="alert" className="security-error">
+          {complianceError}
+        </div>
+      )}
+
+      {complianceReports.length === 0 ? (
+        <p>No compliance reports available.</p>
+      ) : (
+        <div className="security-list">
+          {complianceReports.map(report => (
+            <article key={report.id} className="security-card" data-testid={`compliance-card-${report.id}`}>
+              <header>
+                <h3>{report.name}</h3>
+                <p>
+                  {report.period} • Generated on {formatDate(report.generatedAt)}
+                </p>
+              </header>
+              <p>Status: {report.status}</p>
+              <button
+                type="button"
+                onClick={() => handleComplianceDownload(report.id, report.format)}
+                data-testid={`compliance-download-${report.id}`}
+              >
+                Download {report.format.toUpperCase()}
+              </button>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+
+  return (
+    <div className="security-center" data-testid="security-center">
+      <nav className="security-tabs" aria-label="Security modules">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={activeTab === tab.id ? 'security-tabs__tab--active' : 'security-tabs__tab'}
+            data-testid={`tab-${tab.id}`}
+            aria-pressed={activeTab === tab.id}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="security-content">
+        {activeTab === 'audit' && renderAuditTab()}
+        {activeTab === 'gdpr' && renderGdprTab()}
+        {activeTab === 'incidents' && renderIncidentTab()}
+        {activeTab === 'compliance' && renderComplianceTab()}
+      </div>
+    </div>
+  )
+}
+
+export default SecurityCenter

--- a/src/services/securityService.ts
+++ b/src/services/securityService.ts
@@ -1,0 +1,239 @@
+import axios from 'axios'
+
+const API = import.meta.env.VITE_API_BASE_URL
+
+export type AuditSeverity = 'low' | 'medium' | 'high' | 'critical'
+
+export const AUDIT_SEVERITY_LABELS: Record<AuditSeverity, string> = {
+  low: 'Faible',
+  medium: 'Modérée',
+  high: 'Élevée',
+  critical: 'Critique'
+}
+
+export interface AuditLogEntry {
+  id: string
+  timestamp: string
+  actor: string
+  action: string
+  resourceId?: string
+  resourceType?: string
+  ipAddress?: string
+  location?: string
+  severity: AuditSeverity
+  metadata?: Record<string, unknown>
+}
+
+export interface AuditLogFilters {
+  search?: string
+  actor?: string
+  resourceType?: string
+  severity?: AuditSeverity
+  dateFrom?: string
+  dateTo?: string
+}
+
+export interface AuditLogQuery extends AuditLogFilters {
+  page?: number
+  pageSize?: number
+  sort?: string
+}
+
+export type GdprRequestType =
+  | 'data_access'
+  | 'data_portability'
+  | 'erasure'
+  | 'rectification'
+  | 'consent_withdrawal'
+
+export type GdprRequestStatus =
+  | 'received'
+  | 'in_progress'
+  | 'awaiting_confirmation'
+  | 'completed'
+  | 'rejected'
+
+export const GDPR_STATUS_LABELS: Record<GdprRequestStatus, string> = {
+  received: 'Reçue',
+  in_progress: 'En cours',
+  awaiting_confirmation: 'En attente de confirmation',
+  completed: 'Terminée',
+  rejected: 'Rejetée'
+}
+
+export interface GdprRequest {
+  id: string
+  userId: string
+  userEmail: string
+  type: GdprRequestType
+  submittedAt: string
+  dueAt?: string
+  status: GdprRequestStatus
+  assignedTo?: string
+  notes?: string
+  lastUpdatedAt?: string
+}
+
+export interface GdprRequestListResponse {
+  requests: GdprRequest[]
+  total: number
+}
+
+export interface UpdateGdprStatusPayload {
+  status: GdprRequestStatus
+  assigneeId?: string
+  note?: string
+}
+
+export interface ConfirmGdprActionPayload {
+  confirmationMessage?: string
+  confirmedBy?: string
+}
+
+export interface IncidentStep {
+  id: string
+  title: string
+  description?: string
+  owner?: string
+  expectedCompletionMinutes?: number
+}
+
+export interface IncidentActionLog {
+  id: string
+  stepId: string
+  actor: string
+  note?: string
+  timestamp: string
+  status?: 'pending' | 'completed' | 'skipped'
+}
+
+export interface IncidentPlaybook {
+  id: string
+  name: string
+  description?: string
+  severity: AuditSeverity
+  category: 'availability' | 'privacy' | 'integrity' | 'other'
+  steps: IncidentStep[]
+  actionLog?: IncidentActionLog[]
+}
+
+export interface IncidentActionPayload {
+  stepId: string
+  note?: string
+  status?: 'pending' | 'completed' | 'skipped'
+}
+
+export interface ComplianceReport {
+  id: string
+  name: string
+  period: string
+  framework: 'SOC2' | 'ISO27001' | 'GDPR' | 'Custom'
+  generatedAt: string
+  status: 'in_progress' | 'available' | 'archived'
+  format: 'pdf' | 'csv' | 'json'
+}
+
+export interface AuditLogResponse {
+  logs: AuditLogEntry[]
+  total: number
+}
+
+export interface IncidentPlaybookResponse {
+  playbooks: IncidentPlaybook[]
+}
+
+export interface ComplianceReportResponse {
+  reports: ComplianceReport[]
+}
+
+export const SecurityService = {
+  async listAuditLogs(params: AuditLogQuery) {
+    const query = {
+      ...params,
+      search: params.search || undefined,
+      actor: params.actor || undefined,
+      resourceType: params.resourceType || undefined,
+      severity: params.severity || undefined,
+      dateFrom: params.dateFrom || undefined,
+      dateTo: params.dateTo || undefined
+    }
+
+    const { data } = await axios.get(`${API}/api/security/audit-logs`, { params: query })
+    return data as AuditLogResponse
+  },
+
+  async exportAuditLogs(format: 'csv' | 'json', params: AuditLogQuery) {
+    const query = {
+      ...params,
+      search: params.search || undefined,
+      actor: params.actor || undefined,
+      resourceType: params.resourceType || undefined,
+      severity: params.severity || undefined,
+      dateFrom: params.dateFrom || undefined,
+      dateTo: params.dateTo || undefined,
+      format
+    }
+
+    const { data } = await axios.get(`${API}/api/security/audit-logs/export`, {
+      params: query,
+      responseType: 'blob'
+    })
+    return data as Blob
+  },
+
+  async listGdprRequests() {
+    const { data } = await axios.get(`${API}/api/security/gdpr/requests`)
+    return data as GdprRequestListResponse
+  },
+
+  async updateGdprRequestStatus(requestId: string, payload: UpdateGdprStatusPayload) {
+    const { data } = await axios.post(
+      `${API}/api/security/gdpr/requests/${requestId}/status`,
+      payload
+    )
+    return data as GdprRequest
+  },
+
+  async confirmGdprAction(requestId: string, payload: ConfirmGdprActionPayload = {}) {
+    const { data } = await axios.post(
+      `${API}/api/security/gdpr/requests/${requestId}/confirm`,
+      payload
+    )
+    return data as GdprRequest
+  },
+
+  async downloadGdprArchive(requestId: string) {
+    const { data } = await axios.get(`${API}/api/security/gdpr/requests/${requestId}/archive`, {
+      responseType: 'blob'
+    })
+    return data as Blob
+  },
+
+  async listIncidentPlaybooks() {
+    const { data } = await axios.get(`${API}/api/security/incidents/playbooks`)
+    return data as IncidentPlaybookResponse
+  },
+
+  async logIncidentAction(playbookId: string, payload: IncidentActionPayload) {
+    const { data } = await axios.post(
+      `${API}/api/security/incidents/playbooks/${playbookId}/actions`,
+      payload
+    )
+    return data as IncidentActionLog
+  },
+
+  async listComplianceReports() {
+    const { data } = await axios.get(`${API}/api/security/compliance/reports`)
+    return data as ComplianceReportResponse
+  },
+
+  async downloadComplianceReport(reportId: string) {
+    const { data } = await axios.get(
+      `${API}/api/security/compliance/reports/${reportId}/download`,
+      {
+        responseType: 'blob'
+      }
+    )
+    return data as Blob
+  }
+}

--- a/src/utils/adminNavigation.ts
+++ b/src/utils/adminNavigation.ts
@@ -25,6 +25,12 @@ export const ADMIN_MODULES: AdminModuleConfig[] = [
     description: 'Suivez les signalements et prenez des mesures disciplinaires.'
   },
   {
+    path: 'security',
+    label: 'Sécurité',
+    requiredPermissions: ['security:read'],
+    description: 'Surveillez les logs, demandes GDPR et incidents de sécurité.'
+  },
+  {
     path: 'reports',
     label: 'Rapports',
     requiredPermissions: ['reports:read'],


### PR DESCRIPTION
## Summary
- add a dedicated security service layer covering audit logs, GDPR workflows, incidents, and compliance assets
- introduce the SecurityCenter UI with tabbed navigation, filters, exports, GDPR transitions, and incident playbook logging
- register the new security module in the admin navigation and application routing
- cover permissions, export, and GDPR state transitions with targeted tests

## Testing
- `npx vitest --run --environment jsdom src/__tests__/securityCenter.test.tsx` *(fails: Invalid hook call due to React dispatcher not being initialized when rendering SecurityCenter in isolation)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e18c55408332b77882c8ba32ffb5