### PR TITLE
feat: add unified export utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The admin portal is built with **React 18**, **TypeScript**, and **Vite**. It of
 - **User Management**: Complete CRUD operations for user accounts with advanced filtering and search capabilities
 - **Data Visualization**: Interactive charts and statistics using Chart.js and React Chart.js 2
 - **Bulk Operations**: Perform actions on multiple users simultaneously (activate, deactivate, delete)
-- **Export Functionality**: Export user data to CSV format for external analysis
+- **Export Functionality**: Export data to CSV, Excel (multi-onglets) ou PDF pour l'analyse et l'audit
 - **Pagination**: Efficient handling of large datasets with customizable page sizes
 - **Real-time Filtering**: Debounced search and filtering by status, industry, and date ranges
 
@@ -43,6 +43,16 @@ npm run dev
 ```bash
 npm test
 ```
+
+## Export helpers
+
+Les exports sont centralisés dans `src/utils/export.ts`. Trois fonctions sont disponibles :
+
+- `exportCsv({ filename, data, columns, metadata })`
+- `exportExcel({ filename, sheets, metadata })`
+- `exportPdf({ filename, title, data, columns, metadata })`
+
+Toutes appliquent automatiquement les métadonnées aux journaux (`exportAuditLogger`) afin de tracer les téléchargements. Les colonnes définissent l'ordre et les intitulés des colonnes exportées, tandis que `metadata` permet d'ajouter des informations de contexte (filtres actifs, compteurs, horodatage). Les exports Excel acceptent plusieurs feuilles pour combiner KPI et détails, comme démontré dans `UserManagement`.
 
 Set API base url via `.env`:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "chart.js": "^4.5.0",
         "d3": "^7.9.0",
         "date-fns": "^4.1.0",
+        "pdfmake": "^0.2.20",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^7.8.0"
+        "react-router-dom": "^7.8.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "6.4.8",
@@ -995,6 +997,71 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@foliojs-fork/fontkit": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.2.tgz",
+      "integrity": "sha512-IfB5EiIb+GZk+77TRB86AHroVaqfq8JRFlUbz0WEwsInyCG0epX2tCPOy+UfaWPju30DeVoUAXfzWXmhn753KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/restructure": "^2.0.2",
+        "brotli": "^1.2.0",
+        "clone": "^1.0.4",
+        "deep-equal": "^1.0.0",
+        "dfa": "^1.2.0",
+        "tiny-inflate": "^1.0.2",
+        "unicode-properties": "^1.2.2",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/fontkit/node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@foliojs-fork/linebreak": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.2.tgz",
+      "integrity": "sha512-ZPohpxxbuKNE0l/5iBJnOAfUaMACwvUIKCvqtWGKIMv1lPYoNjYXRfhi9FeeV9McBkBLxsMFWTVVhHJA8cyzvg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/pdfkit": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.15.3.tgz",
+      "integrity": "sha512-Obc0Wmy3bm7BINFVvPhcl2rnSSK61DQrlHU8aXnAqDk9LCjWdUOPwhgD8Ywz5VtuFjRxmVOM/kQ/XLIBjDvltw==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/fontkit": "^1.9.2",
+        "@foliojs-fork/linebreak": "^1.1.1",
+        "crypto-js": "^4.2.0",
+        "jpeg-exif": "^1.1.4",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/restructure": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
+      "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -2156,6 +2223,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2322,6 +2398,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.9.tgz",
@@ -2352,6 +2434,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -2401,7 +2492,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -2433,7 +2523,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2475,6 +2564,19 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/chai": {
       "version": "5.2.1",
@@ -2527,6 +2629,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -2592,6 +2712,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2606,6 +2738,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -3146,7 +3284,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -3164,7 +3301,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -3205,6 +3341,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -3842,6 +3984,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3876,7 +4027,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4070,7 +4220,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -4272,7 +4421,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4353,7 +4501,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4460,7 +4607,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4652,6 +4798,12 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -5037,7 +5189,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -5054,7 +5205,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5147,6 +5297,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -5248,6 +5404,21 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pdfmake": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.20.tgz",
+      "integrity": "sha512-bGbxbGFP5p8PWNT3Phsu1ZcRLnRfF6jmnuKTkgmt6i5PZzSdX6JaB+NeTz9q+aocfW8SE9GUjL3o/5GroBqGcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/linebreak": "^1.1.2",
+        "@foliojs-fork/pdfkit": "^0.15.3",
+        "iconv-lite": "^0.6.3",
+        "xmldoc": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5266,6 +5437,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -5507,7 +5683,6 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -5675,6 +5850,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -5720,7 +5901,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -5738,7 +5918,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -5886,6 +6065,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/stackback": {
@@ -6138,6 +6329,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6317,6 +6514,26 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/universalify": {
@@ -6743,6 +6960,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6883,6 +7118,27 @@
         }
       }
     },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -6899,6 +7155,18 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmldoc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.2.tgz",
+      "integrity": "sha512-UiRwoSStEXS3R+YE8OqYv3jebza8cBBAI2y8g3B15XFkn3SbEOyyLnmPHjLBPZANrPJKEzxxB7A3XwcLikQVlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "chart.js": "^4.5.0",
     "d3": "^7.9.0",
     "date-fns": "^4.1.0",
+    "pdfmake": "^0.2.20",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.8.0"
+    "react-router-dom": "^7.8.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.4.8",

--- a/src/__tests__/authRouting.test.tsx
+++ b/src/__tests__/authRouting.test.tsx
@@ -47,7 +47,7 @@ describe('Auth routing guard', () => {
 
     render(<App />)
 
-    await waitFor(() => expect(screen.getByText('Export CSV')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('Exporter')).toBeInTheDocument())
   })
 
   it('redirige vers /unauthorized lorsque les permissions sont insuffisantes', async () => {

--- a/src/__tests__/exportUtils.test.ts
+++ b/src/__tests__/exportUtils.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const workbookMock = {}
+  const aoaToSheetMock = vi.fn(() => ({}))
+  const bookAppendSheetMock = vi.fn()
+  const writeFileMock = vi.fn()
+  const createPdfDownloadMock = vi.fn((_: string, callback?: () => void) => {
+    callback?.()
+  })
+  const createPdfMock = vi.fn(() => ({ download: createPdfDownloadMock }))
+  const pdfMakeInstance = { vfs: {}, createPdf: createPdfMock }
+
+  return {
+    workbookMock,
+    aoaToSheetMock,
+    bookAppendSheetMock,
+    writeFileMock,
+    createPdfDownloadMock,
+    createPdfMock,
+    pdfMakeInstance,
+    bookNewMock: vi.fn(() => workbookMock)
+  }
+})
+
+const {
+  workbookMock,
+  aoaToSheetMock,
+  bookAppendSheetMock,
+  writeFileMock,
+  createPdfDownloadMock,
+  createPdfMock,
+  pdfMakeInstance,
+  bookNewMock
+} = mocks
+
+vi.mock('xlsx', () => ({
+  utils: {
+    book_new: bookNewMock,
+    aoa_to_sheet: aoaToSheetMock,
+    book_append_sheet: bookAppendSheetMock
+  },
+  writeFileXLSX: writeFileMock
+}))
+
+vi.mock('pdfmake/build/pdfmake', () => ({
+  default: pdfMakeInstance
+}))
+
+vi.mock('pdfmake/build/vfs_fonts', () => ({
+  default: { pdfMake: { vfs: { font: 'data' } } }
+}))
+
+import { exportCsv, exportExcel, exportPdf, exportAuditLogger } from '../utils/export'
+
+describe('export utilities', () => {
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+  const originalCreateElement = document.createElement
+  const originalAppendChild = document.body.appendChild
+  const originalRemoveChild = document.body.removeChild
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+    document.createElement = originalCreateElement
+    document.body.appendChild = originalAppendChild
+    document.body.removeChild = originalRemoveChild
+  })
+
+  it('exports CSV data with metadata and logs the export', async () => {
+    const url = 'blob:csv'
+    URL.createObjectURL = vi.fn(() => url)
+    URL.revokeObjectURL = vi.fn()
+
+    const clickMock = vi.fn()
+    const link = {
+      click: clickMock,
+      style: {},
+      set href(value: string) {
+        this._href = value
+      },
+      get href() {
+        return this._href
+      },
+      set download(value: string) {
+        this._download = value
+      },
+      get download() {
+        return this._download
+      }
+    } as unknown as HTMLAnchorElement & { _href?: string; _download?: string }
+
+    document.createElement = vi.fn(() => link)
+    document.body.appendChild = vi.fn()
+    document.body.removeChild = vi.fn()
+
+    const entries: unknown[] = []
+    const unsubscribe = exportAuditLogger.subscribe(entry => entries.push(entry))
+
+    await exportCsv({
+      filename: 'report',
+      data: [
+        { id: '1', name: 'Alice' },
+        { id: '2', name: 'Bob' }
+      ],
+      columns: [
+        { key: 'id', header: 'ID' },
+        { key: 'name', header: 'Name' }
+      ],
+      metadata: { module: 'test' }
+    })
+
+    unsubscribe()
+
+    expect(link.download).toBe('report.csv')
+    expect(link.href).toBe(url)
+    expect(clickMock).toHaveBeenCalled()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ type: 'csv', metadata: { module: 'test' } })
+  })
+
+  it('builds an Excel workbook with multiple sheets', async () => {
+    const entries: unknown[] = []
+    const unsubscribe = exportAuditLogger.subscribe(entry => entries.push(entry))
+
+    await exportExcel({
+      filename: 'kpis',
+      sheets: [
+        {
+          name: 'Users',
+          data: [
+            { id: '1', name: 'Alice' }
+          ],
+          columns: [
+            { key: 'id', header: 'ID' },
+            { key: 'name', header: 'Name' }
+          ]
+        },
+        {
+          name: 'Stats',
+          data: [
+            { metric: 'Active', value: 42 }
+          ],
+          columns: [
+            { key: 'metric', header: 'Metric' },
+            { key: 'value', header: 'Value' }
+          ]
+        }
+      ],
+      metadata: { total: 2 }
+    })
+
+    unsubscribe()
+
+    expect(bookNewMock).toHaveBeenCalled()
+    expect(aoaToSheetMock).toHaveBeenCalled()
+    expect(bookAppendSheetMock).toHaveBeenCalledTimes(3)
+    expect(writeFileMock).toHaveBeenCalledWith(workbookMock, 'kpis.xlsx')
+    expect(entries[0]).toMatchObject({ type: 'excel', metadata: { total: 2 } })
+  })
+
+  it('generates a PDF report and logs the export', async () => {
+    const entries: unknown[] = []
+    const unsubscribe = exportAuditLogger.subscribe(entry => entries.push(entry))
+
+    await exportPdf({
+      filename: 'audit',
+      title: 'Audit Trail',
+      data: [
+        { id: '1', action: 'Login' }
+      ],
+      columns: [
+        { key: 'id', header: 'ID' },
+        { key: 'action', header: 'Action' }
+      ],
+      metadata: { total: 1 }
+    })
+
+    unsubscribe()
+
+    expect(createPdfMock).toHaveBeenCalled()
+    expect(createPdfDownloadMock).toHaveBeenCalledWith('audit.pdf', expect.any(Function))
+    expect(entries[0]).toMatchObject({ type: 'pdf', metadata: { total: 1 } })
+  })
+})

--- a/src/components/UserActionsBar.tsx
+++ b/src/components/UserActionsBar.tsx
@@ -15,7 +15,7 @@ export function UserActionsBar({ selected, onActivate, onDeactivate, onDelete, o
       <button disabled={disabled} onClick={onActivate}>Activate</button>
       <button disabled={disabled} onClick={onDeactivate}>Deactivate</button>
       <button disabled={disabled} onClick={onDelete}>Delete</button>
-      <button onClick={onExport}>Export CSV</button>
+      <button onClick={onExport}>Exporter</button>
     </div>
   )
 }

--- a/src/services/moderationService.ts
+++ b/src/services/moderationService.ts
@@ -86,7 +86,7 @@ export interface ModerationRuleInput {
   actions: Record<string, unknown>
 }
 
-export interface AuditTrailEntry {
+export interface AuditTrailEntry extends Record<string, unknown> {
   id: string
   timestamp: string
   actor: string

--- a/src/services/securityService.ts
+++ b/src/services/securityService.ts
@@ -11,7 +11,7 @@ export const AUDIT_SEVERITY_LABELS: Record<AuditSeverity, string> = {
   critical: 'Critique'
 }
 
-export interface AuditLogEntry {
+export interface AuditLogEntry extends Record<string, unknown> {
   id: string
   timestamp: string
   actor: string

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-export interface User {
+export interface User extends Record<string, unknown> {
   id: string
   name: string
   email: string
@@ -87,6 +87,12 @@ export interface GeoDistributionBucket {
   longitude?: number
 }
 
+export interface UserExportPayload {
+  users: User[]
+  stats: Stats
+  metadata?: Record<string, unknown>
+}
+
 export const UserService = {
   async list(params: ListParams) {
     const { data } = await axios.get(`${API}/api/users`, { params })
@@ -127,10 +133,9 @@ export const UserService = {
     return data as GeoDistributionBucket[]
   },
   async export(params: ListParams) {
-    const res = await axios.get(`${API}/api/users/export`, {
-      params,
-      responseType: 'blob'
+    const { data } = await axios.get(`${API}/api/users/export`, {
+      params
     })
-    return res.data as Blob
+    return data as UserExportPayload
   }
 }

--- a/src/types/pdfmake.d.ts
+++ b/src/types/pdfmake.d.ts
@@ -1,0 +1,9 @@
+declare module 'pdfmake/build/pdfmake' {
+  import pdfMake from 'pdfmake'
+  export default pdfMake
+}
+
+declare module 'pdfmake/build/vfs_fonts' {
+  const pdfFonts: { pdfMake: { vfs: Record<string, string> } }
+  export default pdfFonts
+}

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,8 +1,0 @@
-export function downloadCsv(blob: Blob, filename: string) {
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,0 +1,262 @@
+import { utils, writeFileXLSX } from 'xlsx'
+import pdfMake from 'pdfmake/build/pdfmake'
+import pdfFonts from 'pdfmake/build/vfs_fonts'
+
+type ExportFormat = 'csv' | 'excel' | 'pdf'
+
+export interface ExportColumn<Row extends Record<string, unknown> = Record<string, unknown>> {
+  key: keyof Row & string
+  header: string
+  formatter?: (value: unknown, row: Row) => unknown
+}
+
+export type ExportMetadata = Record<string, unknown>
+
+export interface ExportCsvOptions<Row extends Record<string, unknown> = Record<string, unknown>> {
+  filename: string
+  data: Row[]
+  columns?: ExportColumn<Row>[]
+  metadata?: ExportMetadata
+  delimiter?: string
+  includeBom?: boolean
+}
+
+export interface ExportExcelSheet<Row extends Record<string, unknown> = Record<string, unknown>> {
+  name: string
+  data: Row[]
+  columns?: ExportColumn<Row>[]
+}
+
+export interface ExportExcelOptions {
+  filename: string
+  sheets: ExportExcelSheet[]
+  metadata?: ExportMetadata
+  includeMetadataSheet?: boolean
+}
+
+export interface ExportPdfOptions<Row extends Record<string, unknown> = Record<string, unknown>> {
+  filename: string
+  title?: string
+  data: Row[]
+  columns: ExportColumn<Row>[]
+  metadata?: ExportMetadata
+  pageOrientation?: 'portrait' | 'landscape'
+}
+
+export interface ExportAuditEntry {
+  type: ExportFormat
+  filename: string
+  rowCount: number
+  metadata?: ExportMetadata
+  timestamp: string
+}
+
+type ExportAuditListener = (entry: ExportAuditEntry) => void
+
+const auditListeners = new Set<ExportAuditListener>()
+
+export const exportAuditLogger = {
+  log(entry: Omit<ExportAuditEntry, 'timestamp'>) {
+    const enriched: ExportAuditEntry = {
+      ...entry,
+      timestamp: new Date().toISOString()
+    }
+    if (auditListeners.size === 0) {
+      // eslint-disable-next-line no-console
+      console.info('[export]', enriched)
+    } else {
+      auditListeners.forEach(listener => listener(enriched))
+    }
+  },
+  subscribe(listener: ExportAuditListener) {
+    auditListeners.add(listener)
+    return () => auditListeners.delete(listener)
+  }
+}
+
+if (pdfFonts?.pdfMake?.vfs) {
+  pdfMake.vfs = pdfFonts.pdfMake.vfs
+}
+
+function ensureExtension(filename: string, extension: string) {
+  return filename.toLowerCase().endsWith(`.${extension}`) ? filename : `${filename}.${extension}`
+}
+
+function normaliseValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return ''
+  }
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  return String(value)
+}
+
+function mapRow<Row extends Record<string, unknown>>(row: Row, columns?: ExportColumn<Row>[]) {
+  if (!columns || columns.length === 0) {
+    return Object.values(row).map(normaliseValue)
+  }
+
+  return columns.map(column => {
+    const raw = row[column.key]
+    const formatted = column.formatter ? column.formatter(raw, row) : raw
+    return normaliseValue(formatted)
+  })
+}
+
+function buildCsvContent<Row extends Record<string, unknown>>(
+  data: Row[],
+  columns?: ExportColumn<Row>[],
+  delimiter = ';'
+) {
+  if (!data.length && (!columns || columns.length === 0)) {
+    return ''
+  }
+
+  const headers = columns && columns.length > 0 ? columns.map(column => column.header) : Object.keys(data[0] || {})
+
+  const csvRows = [headers, ...data.map(row => mapRow(row, columns))]
+
+  return csvRows
+    .map(row =>
+      row
+        .map(value => {
+          const needsQuote = value.includes(delimiter) || value.includes('"') || value.includes('\n')
+          const escaped = value.replace(/"/g, '""')
+          return needsQuote ? `"${escaped}"` : escaped
+        })
+        .join(delimiter)
+    )
+    .join('\n')
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.style.display = 'none'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+export async function exportCsv<Row extends Record<string, unknown>>({
+  filename,
+  data,
+  columns,
+  metadata,
+  delimiter,
+  includeBom
+}: ExportCsvOptions<Row>) {
+  const csvContent = buildCsvContent(data, columns, delimiter)
+  const prefix = includeBom ? '\ufeff' : ''
+  const blob = new Blob([prefix, csvContent], { type: 'text/csv;charset=utf-8;' })
+
+  triggerDownload(blob, ensureExtension(filename, 'csv'))
+  exportAuditLogger.log({ type: 'csv', filename: ensureExtension(filename, 'csv'), rowCount: data.length, metadata })
+}
+
+export async function exportExcel({
+  filename,
+  sheets,
+  metadata,
+  includeMetadataSheet = true
+}: ExportExcelOptions) {
+  if (!sheets.length) {
+    return
+  }
+
+  const workbook = utils.book_new()
+
+  sheets.forEach(sheet => {
+    const headers = sheet.columns && sheet.columns.length > 0 ? sheet.columns.map(column => column.header) : Object.keys(sheet.data[0] || {})
+    const dataRows = sheet.data.map(row => mapRow(row, sheet.columns))
+    const aoa = headers.length ? [headers, ...dataRows] : dataRows
+    const worksheet = utils.aoa_to_sheet(aoa)
+    utils.book_append_sheet(workbook, worksheet, sheet.name.slice(0, 31))
+  })
+
+  if (metadata && includeMetadataSheet && Object.keys(metadata).length > 0) {
+    const metadataRows = Object.entries(metadata).map(([key, value]) => [key, normaliseValue(value)])
+    const worksheet = utils.aoa_to_sheet([
+      ['Clé', 'Valeur'],
+      ...metadataRows
+    ])
+    utils.book_append_sheet(workbook, worksheet, 'Metadata')
+  }
+
+  writeFileXLSX(workbook, ensureExtension(filename, 'xlsx'))
+  const totalRows = sheets.reduce((count, sheet) => count + sheet.data.length, 0)
+  exportAuditLogger.log({ type: 'excel', filename: ensureExtension(filename, 'xlsx'), rowCount: totalRows, metadata })
+}
+
+export async function exportPdf<Row extends Record<string, unknown>>({
+  filename,
+  title,
+  data,
+  columns,
+  metadata,
+  pageOrientation = 'portrait'
+}: ExportPdfOptions<Row>) {
+  if (!columns.length) {
+    return
+  }
+
+  const tableBody = [
+    columns.map(column => ({ text: column.header, style: 'tableHeader' })),
+    ...data.map(row => columns.map(column => ({ text: normaliseValue(column.formatter ? column.formatter(row[column.key], row) : row[column.key]), style: 'tableCell' })))
+  ]
+
+  const docDefinition = {
+    pageOrientation,
+    info: metadata
+      ? Object.entries(metadata).reduce<Record<string, unknown>>((info, [key, value]) => {
+          info[key] = normaliseValue(value)
+          return info
+        }, {})
+      : undefined,
+    content: [
+      title
+        ? {
+            text: title,
+            style: 'title',
+            margin: [0, 0, 0, 12]
+          }
+        : null,
+      {
+        table: {
+          headerRows: 1,
+          widths: columns.map(() => '*'),
+          body: tableBody
+        },
+        layout: 'lightHorizontalLines'
+      }
+    ].filter(Boolean),
+    styles: {
+      title: {
+        fontSize: 16,
+        bold: true
+      },
+      tableHeader: {
+        bold: true,
+        fillColor: '#f2f2f2'
+      },
+      tableCell: {}
+    }
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      pdfMake.createPdf(docDefinition).download(ensureExtension(filename, 'pdf'), () => resolve())
+    } catch (error) {
+      reject(error)
+    }
+  })
+
+  exportAuditLogger.log({ type: 'pdf', filename: ensureExtension(filename, 'pdf'), rowCount: data.length, metadata })
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,9 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     sourcemap: true
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts'
   }
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,30 @@
+import { vi } from 'vitest'
+
+HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+  fillRect: vi.fn(),
+  clearRect: vi.fn(),
+  getImageData: vi.fn(() => ({ data: [] })),
+  putImageData: vi.fn(),
+  createImageData: vi.fn(() => ({ data: [] })),
+  setTransform: vi.fn(),
+  drawImage: vi.fn(),
+  save: vi.fn(),
+  fillText: vi.fn(),
+  restore: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  closePath: vi.fn(),
+  stroke: vi.fn(),
+  translate: vi.fn(),
+  scale: vi.fn(),
+  rotate: vi.fn(),
+  arc: vi.fn(),
+  fill: vi.fn(),
+  measureText: vi.fn(() => ({ width: 0 })),
+  transform: vi.fn(),
+  rect: vi.fn(),
+  clip: vi.fn()
+}))
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn()


### PR DESCRIPTION
## Summary
- replace the legacy CSV helper with a unified export utility that supports CSV, Excel multi-sheet, PDF and audit logging
- update user management, moderation and security flows to use the new helpers and pass structured metadata to exports
- add export utility tests, new vitest setup, and documentation for the helper APIs

## Testing
- `npx vitest run` *(fails: jsdom lacks canvas and navigation implementations, causing chart and axios network errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d9eb94211883328e7ef69875c59045