### PR TITLE
Add finance admin navigation and routing updates

### DIFF
--- a/src/__tests__/authRouting.test.tsx
+++ b/src/__tests__/authRouting.test.tsx
@@ -50,6 +50,28 @@ describe('Auth routing guard', () => {
     await waitFor(() => expect(screen.getByText('Exporter')).toBeInTheDocument())
   })
 
+  it('permet d’accéder au tableau de bord finance avec les permissions adéquates', async () => {
+    window.history.pushState({}, '', '/admin/finance')
+
+    mockedAuthService.getSession.mockResolvedValue({
+      id: '1',
+      email: 'admin@example.com',
+      name: 'Admin Example',
+      role: 'finance-admin'
+    })
+
+    mockedAuthService.getPermissions.mockResolvedValue({
+      permissions: ['admin:access', 'finance:read'],
+      roles: ['finance-admin']
+    })
+
+    render(<App />)
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1, name: 'Tableau de bord financier' })).toBeInTheDocument()
+    )
+  })
+
   it('redirige vers /unauthorized lorsque les permissions sont insuffisantes', async () => {
     window.history.pushState({}, '', '/admin/events')
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { ADMIN_MODULES } from './utils/adminNavigation'
 import { ModerationDashboard } from './components/moderation/ModerationDashboard'
 import { PlatformSettings } from './components/configuration/PlatformSettings'
 import { SecurityCenter } from './components/security/SecurityCenter'
+import { FinancialDashboard } from './components/finance/FinancialDashboard'
 
 interface RequirePermissionsProps {
   requiredPermissions?: string[]
@@ -67,6 +68,25 @@ function ModulePlaceholder({ title, description }: { title: string; description?
   )
 }
 
+function renderModule(path: string, label: string, description?: string) {
+  switch (path) {
+    case 'users':
+      return <UserManagement />
+    case 'events':
+      return <EventManagement />
+    case 'moderation':
+      return <ModerationDashboard />
+    case 'security':
+      return <SecurityCenter />
+    case 'finance':
+      return <FinancialDashboard />
+    case 'configuration':
+      return <PlatformSettings />
+    default:
+      return <ModulePlaceholder title={label} description={description} />
+  }
+}
+
 export default function App() {
   return (
     <BrowserRouter>
@@ -89,19 +109,7 @@ export default function App() {
                   <RequirePermissions
                     requiredPermissions={['admin:access', ...module.requiredPermissions]}
                   >
-                    {module.path === 'users' ? (
-                      <UserManagement />
-                    ) : module.path === 'events' ? (
-                      <EventManagement />
-                    ) : module.path === 'moderation' ? (
-                      <ModerationDashboard />
-                    ) : module.path === 'security' ? (
-                      <SecurityCenter />
-                    ) : module.path === 'configuration' ? (
-                      <PlatformSettings />
-                    ) : (
-                      <ModulePlaceholder title={module.label} description={module.description} />
-                    )}
+                    {renderModule(module.path, module.label, module.description)}
                   </RequirePermissions>
                 }
               />

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -64,7 +64,12 @@ const breadcrumbNavStyle: React.CSSProperties = {
 
 export function AdminLayout() {
   const location = useLocation()
-  const { admin } = usePermissions()
+  const { admin, hasPermissions } = usePermissions()
+
+  const availableModules = useMemo(
+    () => ADMIN_MODULES.filter(module => hasPermissions(module.requiredPermissions)),
+    [hasPermissions]
+  )
 
   const labelMap = useMemo(() => {
     const map = new Map<string, string>()
@@ -93,14 +98,16 @@ export function AdminLayout() {
           <span style={{ fontSize: '1.25rem', fontWeight: 700 }}>Meetinity Admin</span>
         </div>
         <nav aria-label="Navigation principale">
-          {ADMIN_MODULES.map(module => (
+          {availableModules.map(module => (
             <NavLink
               key={module.path}
               to={`/admin/${module.path}`}
               style={({ isActive }) => (isActive ? navLinkActiveStyle : navLinkBaseStyle)}
             >
               <div style={{ fontWeight: 600 }}>{module.label}</div>
-              <div style={{ fontSize: '0.75rem', color: '#9ca3af' }}>{module.description}</div>
+              {module.description && (
+                <div style={{ fontSize: '0.75rem', color: '#9ca3af' }}>{module.description}</div>
+              )}
             </NavLink>
           ))}
         </nav>

--- a/src/utils/adminNavigation.ts
+++ b/src/utils/adminNavigation.ts
@@ -31,21 +31,15 @@ export const ADMIN_MODULES: AdminModuleConfig[] = [
     description: 'Surveillez les logs, demandes GDPR et incidents de sécurité.'
   },
   {
-    path: 'reports',
-    label: 'Rapports',
-    requiredPermissions: ['reports:read'],
-    description: 'Analysez les indicateurs clés de la plateforme.'
+    path: 'finance',
+    label: 'Finances & BI',
+    requiredPermissions: ['finance:read'],
+    description: 'Suivez les performances financières et les indicateurs clés.'
   },
   {
     path: 'configuration',
     label: 'Configuration',
     requiredPermissions: ['platform:config'],
     description: 'Gérez les paramètres et l’orchestration de la plateforme.'
-  },
-  {
-    path: 'settings',
-    label: 'Paramètres',
-    requiredPermissions: ['settings:read'],
-    description: 'Configurez les paramètres globaux et les intégrations.'
   }
 ]


### PR DESCRIPTION
## Summary
- replace placeholder admin navigation entries with the finance module and remove unused routes
- update admin routing/layout to render the financial dashboard and filter navigation to permitted modules
- extend auth routing tests with coverage for the finance dashboard permissions

## Testing
- `npm run test -- --run src/__tests__/authRouting.test.tsx` *(fails: vitest cannot resolve optional browser-only dependencies such as xlsx in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da00f158a48332a3ad348bb3f74306