### PR TITLE
Connect financial dashboard to backend APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The admin portal is built with **React 18**, **TypeScript**, and **Vite**. It of
 
 - **Overall progress**: ~85% of the functional scope has shipped to production-like environments.
 - **Delivered modules**: Users, Events, Moderation, Security, Configuration and Finance are available in the UI with their baseline workflows and dashboards.
-- **In-progress work**: Finance settlement exports still rely on mocked data until the financial modelling backend exposes the `/api/finance/settlements` endpoints. Follow the tracking issue `FIN-128` for updates.
+- **In-progress work**: Align settlement exports with the financial modelling backend once the `/api/finance/settlements` endpoints ship (tracking issue `FIN-128`).
 - **Next iterations**: tighten alerting hooks for moderation SLA breaches and extend security incident automation with playbook-level notifications.
 
 ## Architecture & Modules

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,4 +74,4 @@ Les scripts ajoutés dans `package.json` permettent de cibler chaque domaine :
 | `npm run test:finance` | Dashboard financier et visualisations D3. | `src/__tests__/finance.suite.test.tsx` |
 | `npm run test:security` | Centre de sécurité, GDPR et incidents. | `src/__tests__/security.suite.test.tsx` |
 
-Ces suites partagent des mocks mutualisés (`createMockWebSocket`, `createMockAxios`) définis dans `src/__tests__/utils/networkMocks.ts`.
+Ces suites réutilisent les utilitaires réseau (`createMockWebSocket`, `createMockAxios`) définis dans `src/__tests__/utils/networkMocks.ts`.

--- a/src/__tests__/finance.suite.test.tsx
+++ b/src/__tests__/finance.suite.test.tsx
@@ -1,7 +1,38 @@
-import { describe, expect, it } from 'vitest'
-import { FinancialService, type FinancialFilters } from '../services/financialService'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockAxios, type AxiosMockController } from './utils/networkMocks'
 
-describe('Financial dashboard aggregations', () => {
+import type {
+  FinancialFilters,
+  SubscriptionMetric,
+  CostCategory,
+  CostComparisonPoint,
+  BusinessKpi,
+  CohortPoint,
+  RevenueTrendPoint
+} from '../services/financialService'
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __axiosMockController: AxiosMockController | undefined
+}
+
+vi.mock('axios', () => {
+  const { module, controller } = createMockAxios()
+  globalThis.__axiosMockController = controller
+  return module
+})
+
+let FinancialService: typeof import('../services/financialService').FinancialService
+
+const getAxiosMock = () => {
+  const axiosMock = globalThis.__axiosMockController
+  if (!axiosMock) {
+    throw new Error('Axios mock not initialised')
+  }
+  return axiosMock
+}
+
+describe('FinancialService HTTP integration', () => {
   const baseFilters: FinancialFilters = {
     granularity: 'month',
     plan: 'all',
@@ -10,56 +41,258 @@ describe('Financial dashboard aggregations', () => {
     endDate: '2024-09-30'
   }
 
-  it('applies price variation to revenue trend', async () => {
-    const data = await FinancialService.getRevenueTrend({ ...baseFilters, priceVariation: 10 })
-    expect(data).toHaveLength(3)
-    expect(data[0].period).toBe('2024-07')
-    expect(data[0].revenue).toBeCloseTo(70840, 2)
-    expect(data[0].arpu).toBeCloseTo(85.35, 2)
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:5000')
+    const module = await import('../services/financialService')
+    FinancialService = module.FinancialService
   })
 
-  it('aggregates subscription metrics per plan', async () => {
-    const metrics = await FinancialService.getSubscriptionMetrics({ ...baseFilters, plan: 'basic' })
-    expect(metrics).toHaveLength(1)
-    const [basic] = metrics
-    expect(basic.activeSubscribers).toBe(423)
-    expect(basic.newSubscriptions).toBe(255)
-    expect(basic.churnedSubscriptions).toBe(55)
-    expect(basic.arpu).toBeCloseTo(30, 2)
+  afterEach(() => {
+    getAxiosMock().reset()
+    vi.unstubAllEnvs()
   })
 
-  it('aggregates cost metrics with revenue comparison', async () => {
-    const costMetrics = await FinancialService.getCostMetrics(baseFilters)
-    const marketing = costMetrics.categories.find((category) => category.category === 'Marketing')
-    expect(marketing?.amount).toBeCloseTo(29250, 2)
-    expect(costMetrics.comparison[0]).toMatchObject({ period: '2024-07', cost: 21600, revenue: 64400 })
-    expect(costMetrics.comparison[2]).toMatchObject({ period: '2024-09', cost: 21780, revenue: 69900 })
+  it('normalizes revenue trend responses coming from the finance API', async () => {
+    const axiosMock = getAxiosMock()
+
+    const apiResponse = [
+      {
+        period: '2024-07',
+        revenue: '64400.42',
+        arpu: '85.35',
+        payingUsers: '755',
+        benefit: '42000.11'
+      },
+      {
+        date: '2024-08',
+        totalRevenue: 69900,
+        averageRevenuePerUser: 90.12,
+        subscribers: 780,
+        margin: 45120.55
+      }
+    ]
+
+    axiosMock.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          trend: apiResponse
+        }
+      }
+    })
+
+    const trend = await FinancialService.getRevenueTrend(baseFilters)
+
+    expect(axiosMock.get).toHaveBeenCalledWith('http://localhost:5000/api/finance/revenue-trend', {
+      params: {
+        granularity: 'month',
+        plan: 'all',
+        startDate: '2024-07-01',
+        endDate: '2024-09-30',
+        priceVariation: 0
+      }
+    })
+
+    expect(trend).toHaveLength(2)
+    expect(trend[0]).toMatchObject({
+      period: '2024-07',
+      revenue: 64400.42,
+      arpu: 85.35,
+      payingUsers: 755,
+      benefit: 42000.11
+    } satisfies Partial<RevenueTrendPoint>)
+    expect(trend[1]).toMatchObject({
+      period: '2024-08',
+      revenue: 69900,
+      arpu: 90.12,
+      payingUsers: 780,
+      benefit: 45120.55
+    })
   })
 
-  it('calculates business KPIs across periods', async () => {
+  it('extracts subscription metrics and unique plan options', async () => {
+    const axiosMock = getAxiosMock()
+
+    axiosMock.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          metrics: [
+            {
+              plan: 'basic',
+              active: '420',
+              new: '120',
+              churn: 24,
+              averageRevenue: '30.15'
+            },
+            {
+              segment: 'pro',
+              payingUsers: 290,
+              acquired: 65,
+              lost: 12,
+              revenuePerUser: '82.90'
+            }
+          ],
+          planOptions: ['basic', 'pro', 'basic']
+        }
+      }
+    })
+
+    const response = await FinancialService.getSubscriptionMetrics({ ...baseFilters, plan: 'basic' })
+
+    expect(axiosMock.get).toHaveBeenCalledWith('http://localhost:5000/api/finance/subscriptions', {
+      params: {
+        granularity: 'month',
+        plan: 'basic',
+        startDate: '2024-07-01',
+        endDate: '2024-09-30',
+        priceVariation: 0
+      }
+    })
+
+    expect(response.planOptions).toEqual(['basic', 'pro'])
+    expect(response.metrics).toEqual<SubscriptionMetric[]>([
+      {
+        plan: 'basic',
+        activeSubscribers: 420,
+        newSubscriptions: 120,
+        churnedSubscriptions: 24,
+        arpu: 30.15
+      },
+      {
+        plan: 'pro',
+        activeSubscribers: 290,
+        newSubscriptions: 65,
+        churnedSubscriptions: 12,
+        arpu: 82.9
+      }
+    ])
+  })
+
+  it('maps cost metrics with currency conversion', async () => {
+    const axiosMock = getAxiosMock()
+
+    axiosMock.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          breakdown: [
+            { label: 'Marketing', value: '12500.50' },
+            { label: 'Infrastructure', value: 8200 }
+          ],
+          timeline: [
+            { period: '2024-07', cost: '18200', revenue: '54000.45' },
+            { period: '2024-08', totalCost: 19400, totalRevenue: 59900 }
+          ]
+        }
+      }
+    })
+
+    const costs = await FinancialService.getCostMetrics(baseFilters)
+
+    expect(axiosMock.get).toHaveBeenCalledWith('http://localhost:5000/api/finance/costs', {
+      params: {
+        granularity: 'month',
+        plan: 'all',
+        startDate: '2024-07-01',
+        endDate: '2024-09-30',
+        priceVariation: 0
+      }
+    })
+
+    expect(costs.categories).toEqual<CostCategory[]>([
+      { category: 'Marketing', amount: 12500.5 },
+      { category: 'Infrastructure', amount: 8200 }
+    ])
+
+    expect(costs.comparison).toEqual<CostComparisonPoint[]>([
+      { period: '2024-07', cost: 18200, revenue: 54000.45 },
+      { period: '2024-08', cost: 19400, revenue: 59900 }
+    ])
+  })
+
+  it('parses KPI payloads with decimals', async () => {
+    const axiosMock = getAxiosMock()
+
+    axiosMock.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          indicators: [
+            { label: 'MRR', format: 'currency', value: '69900.15', delta: '250.20' },
+            { label: 'Churn Rate', type: 'percentage', value: 3.25, variation: '-0.15' }
+          ]
+        }
+      }
+    })
+
     const kpis = await FinancialService.getBusinessKpis(baseFilters)
-    const mrr = kpis.find((kpi) => kpi.label === 'MRR')
-    const grossMargin = kpis.find((kpi) => kpi.label === 'Gross Margin')
-    expect(mrr?.value).toBeCloseTo(69900, 2)
-    expect(mrr?.delta).toBeCloseTo(2900, 2)
-    expect(grossMargin?.value).toBeGreaterThan(60)
-    expect(grossMargin?.value).toBeLessThan(80)
+
+    expect(axiosMock.get).toHaveBeenCalledWith('http://localhost:5000/api/finance/kpis', {
+      params: {
+        granularity: 'month',
+        plan: 'all',
+        startDate: '2024-07-01',
+        endDate: '2024-09-30',
+        priceVariation: 0
+      }
+    })
+
+    expect(kpis).toEqual<BusinessKpi[]>([
+      { label: 'MRR', format: 'currency', value: 69900.15, delta: 250.2 },
+      { label: 'Churn Rate', format: 'percentage', value: 3.25, delta: -0.15 }
+    ])
   })
 
-  it('exports aggregated data to multiple formats', async () => {
-    const csvBlob = await FinancialService.exportFinancialData('csv', baseFilters)
-    const csvContent = await csvBlob.text()
-    expect(csvContent).toContain('period,revenue,arpu,payingUsers,benefit')
-    expect(csvContent).toContain('2024-07')
+  it('returns cohort retention points', async () => {
+    const axiosMock = getAxiosMock()
 
-    const excelBlob = await FinancialService.exportFinancialData('excel', baseFilters)
-    const excelContent = await excelBlob.text()
-    expect(excelContent).toContain('Financial Report')
-    expect(excelContent).toContain('Revenue Trend')
+    axiosMock.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          cohorts: [
+            { cohort: '2024-07', period: 'Month 1', plan: 'basic', retention: '1.0' },
+            { batch: '2024-07', step: 'Month 2', code: 'basic', rate: '0.82' }
+          ]
+        }
+      }
+    })
 
-    const pdfBlob = await FinancialService.exportFinancialData('pdf', baseFilters)
-    const pdfContent = await pdfBlob.text()
-    expect(pdfContent).toContain('Financial Report')
-    expect(pdfContent).toContain('Revenue:')
+    const cohorts = await FinancialService.getCohortRetention(baseFilters)
+
+    expect(axiosMock.get).toHaveBeenCalledWith('http://localhost:5000/api/finance/cohorts', {
+      params: {
+        granularity: 'month',
+        plan: 'all',
+        startDate: '2024-07-01',
+        endDate: '2024-09-30',
+        priceVariation: 0
+      }
+    })
+
+    expect(cohorts).toEqual<CohortPoint[]>([
+      { cohort: '2024-07', period: 'Month 1', plan: 'basic', retention: 1 },
+      { cohort: '2024-07', period: 'Month 2', plan: 'basic', retention: 0.82 }
+    ])
+  })
+
+  it('requests export blobs with the selected format', async () => {
+    const axiosMock = getAxiosMock()
+    const blob = new Blob(['period,revenue'], { type: 'text/csv' })
+
+    axiosMock.get.mockResolvedValueOnce({ data: blob })
+
+    const result = await FinancialService.exportFinancialData('csv', baseFilters)
+
+    expect(axiosMock.get).toHaveBeenCalledWith('http://localhost:5000/api/finance/export', {
+      params: {
+        granularity: 'month',
+        plan: 'all',
+        startDate: '2024-07-01',
+        endDate: '2024-09-30',
+        priceVariation: 0,
+        format: 'csv'
+      },
+      responseType: 'blob'
+    })
+
+    expect(result).toBe(blob)
   })
 })

--- a/src/components/finance/BusinessKpiCards.tsx
+++ b/src/components/finance/BusinessKpiCards.tsx
@@ -3,6 +3,7 @@ import { BusinessKpi } from '../../services/financialService'
 
 interface BusinessKpiCardsProps {
   kpis: BusinessKpi[]
+  loading: boolean
 }
 
 const formatValue = (kpi: BusinessKpi) => {
@@ -31,7 +32,15 @@ const formatDelta = (kpi: BusinessKpi) => {
   return `${prefix}${kpi.delta.toFixed(2)}${kpi.format === 'percentage' ? '%' : ''}`
 }
 
-export const BusinessKpiCards: React.FC<BusinessKpiCardsProps> = ({ kpis }) => {
+export const BusinessKpiCards: React.FC<BusinessKpiCardsProps> = ({ kpis, loading }) => {
+  if (loading && !kpis.length) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-6 text-center text-sm text-slate-500">
+        Chargement des indicateurs financiers…
+      </div>
+    )
+  }
+
   if (!kpis.length) {
     return (
       <div className="rounded-lg border border-slate-200 bg-white p-6 text-center text-sm text-slate-500">

--- a/src/components/finance/CostInsights.tsx
+++ b/src/components/finance/CostInsights.tsx
@@ -4,13 +4,18 @@ import { CostMetrics } from '../../services/financialService'
 
 interface CostInsightsProps {
   data: CostMetrics
+  loading: boolean
 }
 
-export const CostInsights: React.FC<CostInsightsProps> = ({ data }) => {
+export const CostInsights: React.FC<CostInsightsProps> = ({ data, loading }) => {
   const comparisonRef = useRef<SVGSVGElement | null>(null)
   const categoriesRef = useRef<SVGSVGElement | null>(null)
 
   const totals = useMemo(() => {
+    if (loading) {
+      return { totalCost: 0, margin: 0 }
+    }
+
     const totalCost = data.categories.reduce((sum, category) => sum + category.amount, 0)
     const lastComparison = data.comparison[data.comparison.length - 1]
     const margin = lastComparison ? lastComparison.revenue - lastComparison.cost : 0
@@ -18,7 +23,7 @@ export const CostInsights: React.FC<CostInsightsProps> = ({ data }) => {
       totalCost,
       margin
     }
-  }, [data])
+  }, [data, loading])
 
   useEffect(() => {
     if (!comparisonRef.current) {
@@ -32,6 +37,17 @@ export const CostInsights: React.FC<CostInsightsProps> = ({ data }) => {
 
     svg.attr('viewBox', `0 0 ${width} ${height}`)
     svg.selectAll('*').remove()
+
+    if (loading) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text('Chargement des coûts...')
+      return
+    }
 
     if (data.comparison.length === 0) {
       svg
@@ -121,7 +137,7 @@ export const CostInsights: React.FC<CostInsightsProps> = ({ data }) => {
       .attr('fill', '#374151')
       .attr('font-size', 12)
       .text('Revenus')
-  }, [data.comparison])
+  }, [data.comparison, loading])
 
   useEffect(() => {
     if (!categoriesRef.current) {
@@ -135,6 +151,17 @@ export const CostInsights: React.FC<CostInsightsProps> = ({ data }) => {
 
     svg.attr('viewBox', `0 0 ${width} ${height}`)
     svg.selectAll('*').remove()
+
+    if (loading) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text('Chargement des catégories...')
+      return
+    }
 
     if (data.categories.length === 0) {
       svg
@@ -194,7 +221,7 @@ export const CostInsights: React.FC<CostInsightsProps> = ({ data }) => {
       .attr('fill', '#4b5563')
       .attr('font-size', 12)
       .text((d) => `€${d.amount.toFixed(0)}`)
-  }, [data.categories])
+  }, [data.categories, loading])
 
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
@@ -206,14 +233,22 @@ export const CostInsights: React.FC<CostInsightsProps> = ({ data }) => {
           </p>
         </div>
         <div className="text-right text-sm text-slate-600">
-          <div>
-            Coûts totaux: <span className="font-semibold text-slate-900">€{totals.totalCost.toLocaleString('fr-FR', { maximumFractionDigits: 0 })}</span>
-          </div>
-          <div>
-            Marge dernière période: <span className={totals.margin >= 0 ? 'text-emerald-600 font-semibold' : 'text-rose-600 font-semibold'}>
-              €{totals.margin.toLocaleString('fr-FR', { maximumFractionDigits: 0 })}
-            </span>
-          </div>
+          {loading ? (
+            <span className="text-slate-400">Chargement…</span>
+          ) : (
+            <>
+              <div>
+                Coûts totaux:{' '}
+                <span className="font-semibold text-slate-900">€{totals.totalCost.toLocaleString('fr-FR', { maximumFractionDigits: 0 })}</span>
+              </div>
+              <div>
+                Marge dernière période:{' '}
+                <span className={totals.margin >= 0 ? 'text-emerald-600 font-semibold' : 'text-rose-600 font-semibold'}>
+                  €{totals.margin.toLocaleString('fr-FR', { maximumFractionDigits: 0 })}
+                </span>
+              </div>
+            </>
+          )}
         </div>
       </div>
       <div className="grid gap-6">

--- a/src/components/finance/SubscriptionManager.tsx
+++ b/src/components/finance/SubscriptionManager.tsx
@@ -6,9 +6,10 @@ interface SubscriptionManagerProps {
   metrics: SubscriptionMetric[]
   cohorts: CohortPoint[]
   granularity: TimeGranularity
+  loading: boolean
 }
 
-export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({ metrics, cohorts, granularity }) => {
+export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({ metrics, cohorts, granularity, loading }) => {
   const histogramRef = useRef<SVGSVGElement | null>(null)
   const heatmapRef = useRef<SVGSVGElement | null>(null)
 
@@ -37,6 +38,17 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({ metric
 
     svg.attr('viewBox', `0 0 ${width} ${height}`)
     svg.selectAll('*').remove()
+
+    if (loading) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text('Chargement des métriques...')
+      return
+    }
 
     if (metrics.length === 0) {
       svg
@@ -97,7 +109,7 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({ metric
       .attr('text-anchor', 'middle')
       .attr('fill', '#4b5563')
       .text('ARPU par plan')
-  }, [metrics])
+  }, [metrics, loading])
 
   useEffect(() => {
     if (!heatmapRef.current) {
@@ -111,6 +123,17 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({ metric
 
     svg.attr('viewBox', `0 0 ${width} ${height}`)
     svg.selectAll('*').remove()
+
+    if (loading) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#6b7280')
+        .text('Chargement des cohortes...')
+      return
+    }
 
     if (cohorts.length === 0) {
       svg
@@ -165,7 +188,7 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({ metric
       .call(d3.axisBottom(xScale))
 
     container.append('g').call(d3.axisLeft(yScale))
-  }, [cohorts])
+  }, [cohorts, loading])
 
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
@@ -177,16 +200,22 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({ metric
           </p>
         </div>
         <div className="text-right text-sm text-slate-600">
-          <div>
-            <span className="font-semibold text-slate-900">{totals.active.toLocaleString('fr-FR')}</span> actifs
-          </div>
-          <div>
-            <span className="font-semibold text-emerald-600">+{totals.newSubs.toLocaleString('fr-FR')}</span> nouveaux
-          </div>
-          <div>
-            <span className="font-semibold text-rose-600">-{totals.churn.toLocaleString('fr-FR')}</span> churn
-          </div>
-          <div>ARPU moyen: €{totals.arpu.toLocaleString('fr-FR')}</div>
+          {loading ? (
+            <span className="text-slate-400">Chargement…</span>
+          ) : (
+            <>
+              <div>
+                <span className="font-semibold text-slate-900">{totals.active.toLocaleString('fr-FR')}</span> actifs
+              </div>
+              <div>
+                <span className="font-semibold text-emerald-600">+{totals.newSubs.toLocaleString('fr-FR')}</span> nouveaux
+              </div>
+              <div>
+                <span className="font-semibold text-rose-600">-{totals.churn.toLocaleString('fr-FR')}</span> churn
+              </div>
+              <div>ARPU moyen: €{totals.arpu.toLocaleString('fr-FR')}</div>
+            </>
+          )}
         </div>
       </div>
       <div className="grid gap-6 md:grid-cols-2">

--- a/src/services/financialService.ts
+++ b/src/services/financialService.ts
@@ -1,7 +1,7 @@
-import { format, parseISO } from 'date-fns'
+import axios from 'axios'
 
 export type TimeGranularity = 'day' | 'week' | 'month'
-export type PlanCode = 'basic' | 'pro' | 'enterprise'
+export type PlanCode = string
 export type PlanFilter = PlanCode | 'all'
 export type ExportFormat = 'csv' | 'excel' | 'pdf'
 
@@ -59,602 +59,369 @@ export interface BusinessKpi {
   format: 'currency' | 'percentage' | 'number'
 }
 
-interface FinancialRecord {
-  date: string
-  plan: PlanCode
-  revenue: number
-  payingUsers: number
-  arpu: number
-  newSubscriptions: number
-  churnedSubscriptions: number
-  marketingSpend: number
-  operationsCost: number
-  infrastructureCost: number
-  supportCost: number
+export interface SubscriptionMetricsResponse {
+  metrics: SubscriptionMetric[]
+  planOptions: PlanCode[]
 }
 
-const financialRecords: FinancialRecord[] = [
-  {
-    date: '2024-07-01',
-    plan: 'basic',
-    revenue: 12000,
-    payingUsers: 400,
-    arpu: 30,
-    newSubscriptions: 80,
-    churnedSubscriptions: 20,
-    marketingSpend: 3000,
-    operationsCost: 1500,
-    infrastructureCost: 1200,
-    supportCost: 800
-  },
-  {
-    date: '2024-07-01',
-    plan: 'pro',
-    revenue: 22400,
-    payingUsers: 280,
-    arpu: 80,
-    newSubscriptions: 60,
-    churnedSubscriptions: 15,
-    marketingSpend: 2600,
-    operationsCost: 1400,
-    infrastructureCost: 1100,
-    supportCost: 900
-  },
-  {
-    date: '2024-07-01',
-    plan: 'enterprise',
-    revenue: 30000,
-    payingUsers: 150,
-    arpu: 200,
-    newSubscriptions: 20,
-    churnedSubscriptions: 5,
-    marketingSpend: 4200,
-    operationsCost: 2100,
-    infrastructureCost: 1600,
-    supportCost: 1200
-  },
-  {
-    date: '2024-08-01',
-    plan: 'basic',
-    revenue: 12600,
-    payingUsers: 420,
-    arpu: 30,
-    newSubscriptions: 85,
-    churnedSubscriptions: 18,
-    marketingSpend: 3050,
-    operationsCost: 1520,
-    infrastructureCost: 1200,
-    supportCost: 820
-  },
-  {
-    date: '2024-08-01',
-    plan: 'pro',
-    revenue: 23200,
-    payingUsers: 290,
-    arpu: 80,
-    newSubscriptions: 65,
-    churnedSubscriptions: 14,
-    marketingSpend: 2550,
-    operationsCost: 1350,
-    infrastructureCost: 1100,
-    supportCost: 910
-  },
-  {
-    date: '2024-08-01',
-    plan: 'enterprise',
-    revenue: 31200,
-    payingUsers: 156,
-    arpu: 200,
-    newSubscriptions: 22,
-    churnedSubscriptions: 4,
-    marketingSpend: 4150,
-    operationsCost: 2050,
-    infrastructureCost: 1650,
-    supportCost: 1180
-  },
-  {
-    date: '2024-09-01',
-    plan: 'basic',
-    revenue: 13500,
-    payingUsers: 450,
-    arpu: 30,
-    newSubscriptions: 90,
-    churnedSubscriptions: 17,
-    marketingSpend: 3100,
-    operationsCost: 1580,
-    infrastructureCost: 1250,
-    supportCost: 830
-  },
-  {
-    date: '2024-09-01',
-    plan: 'pro',
-    revenue: 24000,
-    payingUsers: 300,
-    arpu: 80,
-    newSubscriptions: 70,
-    churnedSubscriptions: 13,
-    marketingSpend: 2500,
-    operationsCost: 1380,
-    infrastructureCost: 1120,
-    supportCost: 920
-  },
-  {
-    date: '2024-09-01',
-    plan: 'enterprise',
-    revenue: 32400,
-    payingUsers: 162,
-    arpu: 200,
-    newSubscriptions: 25,
-    churnedSubscriptions: 4,
-    marketingSpend: 4100,
-    operationsCost: 2100,
-    infrastructureCost: 1700,
-    supportCost: 1200
-  }
-]
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '')
+const FINANCE_API_BASE = `${API_BASE_URL}/api/finance`
 
-const cohortRetention: CohortPoint[] = [
-  { cohort: '2024-07', period: 'Month 1', retention: 1, plan: 'basic' },
-  { cohort: '2024-07', period: 'Month 2', retention: 0.82, plan: 'basic' },
-  { cohort: '2024-07', period: 'Month 3', retention: 0.74, plan: 'basic' },
-  { cohort: '2024-07', period: 'Month 1', retention: 1, plan: 'pro' },
-  { cohort: '2024-07', period: 'Month 2', retention: 0.87, plan: 'pro' },
-  { cohort: '2024-07', period: 'Month 3', retention: 0.8, plan: 'pro' },
-  { cohort: '2024-07', period: 'Month 1', retention: 1, plan: 'enterprise' },
-  { cohort: '2024-07', period: 'Month 2', retention: 0.91, plan: 'enterprise' },
-  { cohort: '2024-07', period: 'Month 3', retention: 0.85, plan: 'enterprise' },
-  { cohort: '2024-08', period: 'Month 1', retention: 1, plan: 'basic' },
-  { cohort: '2024-08', period: 'Month 2', retention: 0.83, plan: 'basic' },
-  { cohort: '2024-08', period: 'Month 3', retention: 0.76, plan: 'basic' },
-  { cohort: '2024-08', period: 'Month 1', retention: 1, plan: 'pro' },
-  { cohort: '2024-08', period: 'Month 2', retention: 0.88, plan: 'pro' },
-  { cohort: '2024-08', period: 'Month 3', retention: 0.81, plan: 'pro' },
-  { cohort: '2024-08', period: 'Month 1', retention: 1, plan: 'enterprise' },
-  { cohort: '2024-08', period: 'Month 2', retention: 0.92, plan: 'enterprise' },
-  { cohort: '2024-08', period: 'Month 3', retention: 0.86, plan: 'enterprise' },
-  { cohort: '2024-09', period: 'Month 1', retention: 1, plan: 'basic' },
-  { cohort: '2024-09', period: 'Month 2', retention: 0.84, plan: 'basic' },
-  { cohort: '2024-09', period: 'Month 3', retention: 0.77, plan: 'basic' },
-  { cohort: '2024-09', period: 'Month 1', retention: 1, plan: 'pro' },
-  { cohort: '2024-09', period: 'Month 2', retention: 0.89, plan: 'pro' },
-  { cohort: '2024-09', period: 'Month 3', retention: 0.82, plan: 'pro' },
-  { cohort: '2024-09', period: 'Month 1', retention: 1, plan: 'enterprise' },
-  { cohort: '2024-09', period: 'Month 2', retention: 0.93, plan: 'enterprise' },
-  { cohort: '2024-09', period: 'Month 3', retention: 0.87, plan: 'enterprise' }
-]
-
-const planOptions: PlanCode[] = ['basic', 'pro', 'enterprise']
-
-const getMultiplier = (variation?: number) => 1 + (variation ?? 0) / 100
-
-const getPeriodKey = (date: string, granularity: TimeGranularity) => {
-  const parsed = parseISO(date)
-  if (granularity === 'week') {
-    return format(parsed, 'yyyy-ww')
-  }
-
-  if (granularity === 'month') {
-    return format(parsed, 'yyyy-MM')
-  }
-
-  return format(parsed, 'yyyy-MM-dd')
+const MIME_TYPES: Record<ExportFormat, string> = {
+  csv: 'text/csv',
+  excel: 'application/vnd.ms-excel',
+  pdf: 'application/pdf'
 }
 
-const sortPeriods = (points: RevenueTrendPoint[]) =>
-  [...points].sort((a, b) => (a.period > b.period ? 1 : -1))
+const unwrapData = (payload: unknown): unknown => {
+  let current = payload
+  while (current && typeof current === 'object' && 'data' in (current as Record<string, unknown>)) {
+    current = (current as Record<string, unknown>).data
+  }
+  return current
+}
 
-const filterRecords = ({ plan, startDate, endDate }: FinancialFilters) => {
-  return financialRecords.filter((record) => {
-    if (plan !== 'all' && record.plan !== plan) {
-      return false
+const extractArray = (payload: unknown, keys: string[]): unknown[] => {
+  const unwrapped = unwrapData(payload)
+  if (Array.isArray(unwrapped)) {
+    return unwrapped
+  }
+
+  if (!unwrapped || typeof unwrapped !== 'object') {
+    return []
+  }
+
+  for (const key of keys) {
+    const value = (unwrapped as Record<string, unknown>)[key]
+    if (Array.isArray(value)) {
+      return value
     }
-
-    if (startDate && record.date < startDate) {
-      return false
-    }
-
-    if (endDate && record.date > endDate) {
-      return false
-    }
-
-    return true
-  })
-}
-
-const computeCost = (record: FinancialRecord) =>
-  record.marketingSpend +
-  record.operationsCost +
-  record.infrastructureCost +
-  record.supportCost
-
-const formatNumber = (value: number, format: BusinessKpi['format']) => {
-  if (format === 'currency') {
-    return Number(value.toFixed(2))
   }
 
-  if (format === 'percentage') {
-    return Number((value * 100).toFixed(2))
+  return []
+}
+
+const toNumber = (value: unknown): number => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0
   }
 
-  return Number(value.toFixed(2))
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0
+  }
+
+  return 0
 }
 
-const createCsv = (dataset: {
-  revenueTrend: RevenueTrendPoint[]
-  subscriptionMetrics: SubscriptionMetric[]
-  costMetrics: CostMetrics
-  kpis: BusinessKpi[]
-}) => {
-  const revenueRows = ['period,revenue,arpu,payingUsers,benefit']
-  revenueRows.push(
-    ...dataset.revenueTrend.map((point) =>
-      [point.period, point.revenue.toFixed(2), point.arpu.toFixed(2), point.payingUsers, point.benefit.toFixed(2)].join(',')
-    )
-  )
-
-  const subscriptionHeader = '\nplan,activeSubscribers,newSubscriptions,churnedSubscriptions,arpu'
-  const subscriptionRows = dataset.subscriptionMetrics
-    .map((metric) =>
-      [
-        metric.plan,
-        metric.activeSubscribers.toFixed(0),
-        metric.newSubscriptions.toFixed(0),
-        metric.churnedSubscriptions.toFixed(0),
-        metric.arpu.toFixed(2)
-      ].join(',')
-    )
-    .join('\n')
-
-  const costHeader = '\ncategory,amount'
-  const costRows = dataset.costMetrics.categories
-    .map((category) => `${category.category},${category.amount.toFixed(2)}`)
-    .join('\n')
-
-  const kpiHeader = '\nlabel,value,delta,format'
-  const kpiRows = dataset.kpis
-    .map((kpi) => `${kpi.label},${kpi.value.toFixed(2)},${kpi.delta.toFixed(2)},${kpi.format}`)
-    .join('\n')
-
-  return `${revenueRows.join('\n')}${subscriptionHeader}${subscriptionRows}${costHeader}${costRows}${kpiHeader}${kpiRows}`
+const toInteger = (value: unknown): number => {
+  const result = Math.round(toNumber(value))
+  return Number.isFinite(result) ? result : 0
 }
 
-const createExcel = (dataset: {
-  revenueTrend: RevenueTrendPoint[]
-  subscriptionMetrics: SubscriptionMetric[]
-  costMetrics: CostMetrics
-  kpis: BusinessKpi[]
-}) => {
-  const sections = ['Financial Report']
-  sections.push('Revenue Trend')
-  sections.push('Period\tRevenue\tARPU\tPaying Users\tBenefit')
-  sections.push(
-    ...dataset.revenueTrend.map(
-      (point) =>
-        `${point.period}\t${point.revenue.toFixed(2)}\t${point.arpu.toFixed(2)}\t${point.payingUsers}\t${point.benefit.toFixed(2)}`
-    )
-  )
+const ensureString = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value
+  }
 
-  sections.push('\nSubscription Metrics')
-  sections.push('Plan\tActive Subscribers\tNew\tChurned\tARPU')
-  sections.push(
-    ...dataset.subscriptionMetrics.map(
-      (metric) =>
-        `${metric.plan}\t${metric.activeSubscribers.toFixed(0)}\t${metric.newSubscriptions.toFixed(0)}\t${metric.churnedSubscriptions.toFixed(0)}\t${metric.arpu.toFixed(2)}`
-    )
-  )
+  if (value == null) {
+    return ''
+  }
 
-  sections.push('\nCost Breakdown')
-  sections.push('Category\tAmount')
-  sections.push(
-    ...dataset.costMetrics.categories.map((category) => `${category.category}\t${category.amount.toFixed(2)}`)
-  )
-
-  sections.push('\nKey KPIs')
-  sections.push('Label\tValue\tDelta\tFormat')
-  sections.push(
-    ...dataset.kpis.map((kpi) => `${kpi.label}\t${kpi.value.toFixed(2)}\t${kpi.delta.toFixed(2)}\t${kpi.format}`)
-  )
-
-  return sections.join('\n')
+  return String(value)
 }
 
-const createPdf = (dataset: {
-  revenueTrend: RevenueTrendPoint[]
-  subscriptionMetrics: SubscriptionMetric[]
-  costMetrics: CostMetrics
-  kpis: BusinessKpi[]
-}) => {
-  const lines = ['Financial Report']
-  lines.push('Revenue Trend:')
-  lines.push(
-    ...dataset.revenueTrend.map(
-      (point) =>
-        `${point.period} -> Revenue: ${point.revenue.toFixed(2)}, ARPU: ${point.arpu.toFixed(2)}, Paying Users: ${point.payingUsers}`
-    )
-  )
-  lines.push('\nSubscription Metrics:')
-  lines.push(
-    ...dataset.subscriptionMetrics.map(
-      (metric) =>
-        `${metric.plan} Plan - Active: ${metric.activeSubscribers.toFixed(0)}, New: ${metric.newSubscriptions.toFixed(0)}, Churned: ${metric.churnedSubscriptions.toFixed(0)}, ARPU: ${metric.arpu.toFixed(2)}`
-    )
-  )
+const ensurePlanOptions = (payload: unknown): PlanCode[] => {
+  const values = extractArray(payload, ['plans', 'planOptions', 'availablePlans'])
+  const plans = values
+    .map((value) => ensureString(value))
+    .filter((plan) => plan.length > 0)
 
-  lines.push('\nCost Breakdown:')
-  lines.push(...dataset.costMetrics.categories.map((category) => `${category.category}: ${category.amount.toFixed(2)}`))
-
-  lines.push('\nKPIs:')
-  lines.push(...dataset.kpis.map((kpi) => `${kpi.label}: ${kpi.value.toFixed(2)} (${kpi.delta.toFixed(2)})`))
-
-  return lines.join('\n')
+  return Array.from(new Set(plans))
 }
 
-const createBlobWithFallback = (content: string, type: string): Blob => {
-  const blob = new Blob([content], { type })
+const mapRevenueTrend = (payload: unknown): RevenueTrendPoint[] => {
+  const rows = extractArray(payload, ['trend', 'items', 'points', 'rows'])
+
+  return rows
+    .map((row) => {
+      if (!row || typeof row !== 'object') {
+        return null
+      }
+
+      const entry = row as Record<string, unknown>
+      const period = ensureString(entry.period ?? entry.date ?? entry.window)
+      if (!period) {
+        return null
+      }
+
+      return {
+        period,
+        revenue: Number(toNumber(entry.revenue ?? entry.amount ?? entry.totalRevenue).toFixed(2)),
+        arpu: Number(toNumber(entry.arpu ?? entry.averageRevenuePerUser ?? entry.avgRevenue).toFixed(2)),
+        payingUsers: toInteger(entry.payingUsers ?? entry.users ?? entry.subscribers),
+        benefit: Number(toNumber(entry.benefit ?? entry.margin ?? entry.grossProfit).toFixed(2))
+      }
+    })
+    .filter((row): row is RevenueTrendPoint => row !== null)
+}
+
+const mapSubscriptionMetrics = (payload: unknown): SubscriptionMetricsResponse => {
+  const metricsPayload = unwrapData(payload)
+  const metricsRows = extractArray(metricsPayload, ['metrics', 'items', 'subscriptions'])
+
+  const metrics = metricsRows
+    .map((row) => {
+      if (!row || typeof row !== 'object') {
+        return null
+      }
+
+      const entry = row as Record<string, unknown>
+      const plan = ensureString(entry.plan ?? entry.segment ?? entry.code)
+      if (!plan) {
+        return null
+      }
+
+      return {
+        plan,
+        activeSubscribers: toInteger(entry.activeSubscribers ?? entry.active ?? entry.payingUsers),
+        newSubscriptions: toInteger(entry.newSubscriptions ?? entry.new ?? entry.acquired),
+        churnedSubscriptions: toInteger(entry.churnedSubscriptions ?? entry.churn ?? entry.lost),
+        arpu: Number(toNumber(entry.arpu ?? entry.averageRevenue ?? entry.revenuePerUser).toFixed(2))
+      }
+    })
+    .filter((metric): metric is SubscriptionMetric => metric !== null)
+
+  const planOptions = ensurePlanOptions(metricsPayload)
+
+  return {
+    metrics,
+    planOptions
+  }
+}
+
+const mapCostMetrics = (payload: unknown): CostMetrics => {
+  const unwrapped = unwrapData(payload)
+  const categoriesRaw = extractArray(unwrapped, ['categories', 'breakdown', 'costs'])
+  const comparisonRaw = extractArray(unwrapped, ['comparison', 'timeline', 'series'])
+
+  const categories = categoriesRaw
+    .map((row) => {
+      if (!row || typeof row !== 'object') {
+        return null
+      }
+
+      const entry = row as Record<string, unknown>
+      const category = ensureString(entry.category ?? entry.label ?? entry.name)
+      if (!category) {
+        return null
+      }
+
+      return {
+        category,
+        amount: Number(toNumber(entry.amount ?? entry.value ?? entry.total).toFixed(2))
+      }
+    })
+    .filter((category): category is CostCategory => category !== null)
+
+  const comparison = comparisonRaw
+    .map((row) => {
+      if (!row || typeof row !== 'object') {
+        return null
+      }
+
+      const entry = row as Record<string, unknown>
+      const period = ensureString(entry.period ?? entry.date ?? entry.window)
+      if (!period) {
+        return null
+      }
+
+      return {
+        period,
+        cost: Number(toNumber(entry.cost ?? entry.amount ?? entry.totalCost).toFixed(2)),
+        revenue: Number(toNumber(entry.revenue ?? entry.totalRevenue ?? entry.turnover).toFixed(2))
+      }
+    })
+    .filter((row): row is CostComparisonPoint => row !== null)
+
+  return {
+    categories,
+    comparison
+  }
+}
+
+const mapCohorts = (payload: unknown): CohortPoint[] => {
+  const rows = extractArray(payload, ['cohorts', 'items', 'retention'])
+
+  return rows
+    .map((row) => {
+      if (!row || typeof row !== 'object') {
+        return null
+      }
+
+      const entry = row as Record<string, unknown>
+      const cohort = ensureString(entry.cohort ?? entry.batch)
+      const period = ensureString(entry.period ?? entry.step ?? entry.label)
+      const plan = ensureString(entry.plan ?? entry.segment ?? entry.code)
+
+      if (!cohort || !period || !plan) {
+        return null
+      }
+
+      return {
+        cohort,
+        period,
+        plan,
+        retention: Number(toNumber(entry.retention ?? entry.rate ?? entry.value).toFixed(4))
+      }
+    })
+    .filter((row): row is CohortPoint => row !== null)
+}
+
+const mapBusinessKpis = (payload: unknown): BusinessKpi[] => {
+  const rows = extractArray(payload, ['kpis', 'items', 'indicators'])
+
+  return rows
+    .map((row) => {
+      if (!row || typeof row !== 'object') {
+        return null
+      }
+
+      const entry = row as Record<string, unknown>
+      const label = ensureString(entry.label ?? entry.name)
+      const format = ensureString(entry.format ?? entry.type) as BusinessKpi['format']
+
+      if (!label || !format) {
+        return null
+      }
+
+      return {
+        label,
+        format: format === 'currency' || format === 'percentage' || format === 'number' ? format : 'number',
+        value: Number(toNumber(entry.value ?? entry.amount ?? entry.current).toFixed(2)),
+        delta: Number(toNumber(entry.delta ?? entry.diff ?? entry.variation).toFixed(2))
+      }
+    })
+    .filter((row): row is BusinessKpi => row !== null)
+}
+
+const withTextFallback = (blob: Blob, origin?: string): Blob => {
   const candidate = blob as Blob & { text?: () => Promise<string> }
-  if (typeof candidate.text !== 'function') {
+
+  if (typeof candidate.text !== 'function' && typeof origin === 'string') {
     Object.defineProperty(candidate, 'text', {
-      value: async () => content,
+      value: async () => origin,
       configurable: true
     })
   }
 
-  return blob
+  return candidate
 }
 
-const aggregateRevenue = (filters: FinancialFilters): RevenueTrendPoint[] => {
-  const multiplier = getMultiplier(filters.priceVariation)
-  const records = filterRecords(filters)
-  const buckets = new Map<
-    string,
-    {
-      revenue: number
-      payingUsers: number
-      arpuWeighted: number
-      cost: number
-    }
-  >()
-
-  records.forEach((record) => {
-    const key = getPeriodKey(record.date, filters.granularity)
-    const bucket = buckets.get(key) ?? {
-      revenue: 0,
-      payingUsers: 0,
-      arpuWeighted: 0,
-      cost: 0
-    }
-
-    const adjustedRevenue = record.revenue * multiplier
-    const adjustedArpu = record.arpu * multiplier
-
-    bucket.revenue += adjustedRevenue
-    bucket.payingUsers += record.payingUsers
-    bucket.arpuWeighted += adjustedArpu * record.payingUsers
-    bucket.cost += computeCost(record)
-
-    buckets.set(key, bucket)
-  })
-
-  const points = Array.from(buckets.entries()).map(([period, value]) => ({
-    period,
-    revenue: Number(value.revenue.toFixed(2)),
-    arpu: value.payingUsers ? Number((value.arpuWeighted / value.payingUsers).toFixed(2)) : 0,
-    payingUsers: value.payingUsers,
-    benefit: Number((value.revenue - value.cost).toFixed(2))
-  }))
-
-  return sortPeriods(points)
-}
-
-const aggregateSubscriptions = (filters: FinancialFilters): SubscriptionMetric[] => {
-  const multiplier = getMultiplier(filters.priceVariation)
-  const records = filterRecords({ ...filters, plan: 'all' })
-  const buckets = new Map<PlanCode, {
-    payingUsers: number
-    entries: number
-    newSubscriptions: number
-    churnedSubscriptions: number
-    arpuWeighted: number
-  }>()
-
-  records.forEach((record) => {
-    if (filters.plan !== 'all' && record.plan !== filters.plan) {
-      return
-    }
-
-    const bucket = buckets.get(record.plan) ?? {
-      payingUsers: 0,
-      entries: 0,
-      newSubscriptions: 0,
-      churnedSubscriptions: 0,
-      arpuWeighted: 0
-    }
-
-    bucket.payingUsers += record.payingUsers
-    bucket.entries += 1
-    bucket.newSubscriptions += record.newSubscriptions
-    bucket.churnedSubscriptions += record.churnedSubscriptions
-    bucket.arpuWeighted += record.arpu * multiplier * record.payingUsers
-
-    buckets.set(record.plan, bucket)
-  })
-
-  return planOptions
-    .filter((plan) => buckets.has(plan))
-    .map((plan) => {
-      const bucket = buckets.get(plan)!
-      const active = bucket.payingUsers / bucket.entries
-      const arpu = bucket.payingUsers
-        ? Number((bucket.arpuWeighted / bucket.payingUsers).toFixed(2))
-        : 0
-
-      return {
-        plan,
-        activeSubscribers: Number(active.toFixed(0)),
-        newSubscriptions: Number(bucket.newSubscriptions.toFixed(0)),
-        churnedSubscriptions: Number(bucket.churnedSubscriptions.toFixed(0)),
-        arpu
-      }
-    })
-}
-
-const aggregateCosts = (filters: FinancialFilters): CostMetrics => {
-  const multiplier = getMultiplier(filters.priceVariation)
-  const records = filterRecords(filters)
-  const categoryTotals: Record<string, number> = {
-    Marketing: 0,
-    Operations: 0,
-    Infrastructure: 0,
-    Support: 0
+const ensureBlob = (value: unknown, format: ExportFormat): Blob => {
+  if (value instanceof Blob) {
+    return withTextFallback(value)
   }
-  const comparisonMap = new Map<string, { cost: number; revenue: number }>()
 
-  records.forEach((record) => {
-    const key = getPeriodKey(record.date, filters.granularity)
-    const cost = computeCost(record)
-    const adjustedRevenue = record.revenue * multiplier
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
 
-    categoryTotals.Marketing += record.marketingSpend
-    categoryTotals.Operations += record.operationsCost
-    categoryTotals.Infrastructure += record.infrastructureCost
-    categoryTotals.Support += record.supportCost
+    if (record.content instanceof Blob) {
+      return withTextFallback(record.content)
+    }
 
-    const comparison = comparisonMap.get(key) ?? { cost: 0, revenue: 0 }
-    comparison.cost += cost
-    comparison.revenue += adjustedRevenue
-    comparisonMap.set(key, comparison)
-  })
+    if (typeof record.content === 'string') {
+      const type = ensureString(record.mimeType ?? record.type) || MIME_TYPES[format]
+      return withTextFallback(new Blob([record.content], { type }), record.content)
+    }
 
-  return {
-    categories: Object.entries(categoryTotals).map(([category, amount]) => ({
-      category,
-      amount: Number(amount.toFixed(2))
-    })),
-    comparison: sortPeriods(
-      Array.from(comparisonMap.entries()).map(([period, values]) => ({
-        period,
-        cost: Number(values.cost.toFixed(2)),
-        revenue: Number(values.revenue.toFixed(2))
-      }))
-    )
+    if (record.buffer instanceof ArrayBuffer) {
+      const type = ensureString(record.mimeType ?? record.type) || MIME_TYPES[format]
+      return withTextFallback(new Blob([record.buffer], { type }))
+    }
   }
+
+  if (typeof value === 'string') {
+    return withTextFallback(new Blob([value], { type: MIME_TYPES[format] }), value)
+  }
+
+  const fallback = JSON.stringify(value ?? {})
+  return withTextFallback(new Blob([fallback], { type: 'application/json' }), fallback)
 }
 
-const aggregateKpis = (filters: FinancialFilters): BusinessKpi[] => {
-  const revenueTrend = aggregateRevenue(filters)
-  const costMetrics = aggregateCosts(filters)
-  const subscriptions = aggregateSubscriptions(filters)
+const buildQueryParams = (filters: FinancialFilters) => {
+  const params: Record<string, string | number> = {
+    granularity: filters.granularity,
+    plan: filters.plan
+  }
 
-  const totalRevenue = revenueTrend.reduce((sum, point) => sum + point.revenue, 0)
-  const totalCost = costMetrics.comparison.reduce((sum, point) => sum + point.cost, 0)
-  const totalPayingUsers = revenueTrend.reduce((sum, point) => sum + point.payingUsers, 0)
-  const totalNewSubscriptions = subscriptions.reduce((sum, metric) => sum + metric.newSubscriptions, 0)
-  const totalChurned = subscriptions.reduce((sum, metric) => sum + metric.churnedSubscriptions, 0)
+  if (filters.startDate) {
+    params.startDate = filters.startDate
+  }
 
-  const lastPeriod = revenueTrend[revenueTrend.length - 1]
-  const previousPeriod = revenueTrend[revenueTrend.length - 2]
+  if (filters.endDate) {
+    params.endDate = filters.endDate
+  }
 
-  const mrr = lastPeriod ? lastPeriod.revenue : 0
-  const arr = mrr * 12
+  if (typeof filters.priceVariation === 'number') {
+    params.priceVariation = filters.priceVariation
+  }
 
-  const averageArpu = totalPayingUsers
-    ? Number((totalRevenue / totalPayingUsers).toFixed(2))
-    : 0
-
-  const churnRate = totalPayingUsers
-    ? Number((totalChurned / (totalChurned + totalPayingUsers)).toFixed(4))
-    : 0
-
-  const grossMargin = totalRevenue
-    ? Number(((totalRevenue - totalCost) / totalRevenue).toFixed(4))
-    : 0
-
-  const ltv = churnRate > 0 ? Number(((averageArpu * grossMargin) / churnRate).toFixed(2)) : 0
-
-  const cac = totalNewSubscriptions > 0 ? Number((totalCost / totalNewSubscriptions).toFixed(2)) : 0
-
-  const costPerUser = totalPayingUsers > 0 ? totalCost / totalPayingUsers : 0
-  const netContribution = averageArpu - costPerUser
-  const paybackPeriod = netContribution > 0 && cac > 0 ? Number((cac / netContribution).toFixed(2)) : 0
-
-  const revenueDelta = previousPeriod ? Number((lastPeriod.revenue - previousPeriod.revenue).toFixed(2)) : 0
-
-  return [
-    { label: 'MRR', value: formatNumber(mrr, 'currency'), delta: revenueDelta, format: 'currency' },
-    { label: 'ARR', value: formatNumber(arr, 'currency'), delta: revenueDelta * 12, format: 'currency' },
-    { label: 'ARPU', value: formatNumber(averageArpu, 'currency'), delta: 0, format: 'currency' },
-    { label: 'Churn Rate', value: formatNumber(churnRate, 'percentage'), delta: 0, format: 'percentage' },
-    { label: 'LTV', value: formatNumber(ltv, 'currency'), delta: 0, format: 'currency' },
-    { label: 'CAC', value: formatNumber(cac, 'currency'), delta: 0, format: 'currency' },
-    { label: 'Payback Period (months)', value: formatNumber(paybackPeriod, 'number'), delta: 0, format: 'number' },
-    { label: 'Gross Margin', value: formatNumber(grossMargin, 'percentage'), delta: 0, format: 'percentage' }
-  ]
-}
-
-const filterCohorts = (filters: FinancialFilters): CohortPoint[] => {
-  return cohortRetention.filter((point) => {
-    if (filters.plan !== 'all' && point.plan !== filters.plan) {
-      return false
-    }
-
-    if (filters.startDate && `${point.cohort}-01` < filters.startDate) {
-      return false
-    }
-
-    if (filters.endDate && `${point.cohort}-01` > filters.endDate) {
-      return false
-    }
-
-    return true
-  })
-}
-
-const getExportPayload = async (filters: FinancialFilters) => {
-  const [revenueTrend, subscriptionMetrics, costMetrics, kpis] = await Promise.all([
-    FinancialService.getRevenueTrend(filters),
-    FinancialService.getSubscriptionMetrics(filters),
-    FinancialService.getCostMetrics(filters),
-    FinancialService.getBusinessKpis(filters)
-  ])
-
-  return { revenueTrend, subscriptionMetrics, costMetrics, kpis }
+  return params
 }
 
 export const FinancialService = {
-  getPlanOptions(): PlanCode[] {
-    return [...planOptions]
-  },
   async getRevenueTrend(filters: FinancialFilters): Promise<RevenueTrendPoint[]> {
-    return aggregateRevenue(filters)
+    const { data } = await axios.get(`${FINANCE_API_BASE}/revenue-trend`, {
+      params: buildQueryParams(filters)
+    })
+
+    return mapRevenueTrend(data)
   },
-  async getSubscriptionMetrics(filters: FinancialFilters): Promise<SubscriptionMetric[]> {
-    return aggregateSubscriptions(filters)
+
+  async getSubscriptionMetrics(filters: FinancialFilters): Promise<SubscriptionMetricsResponse> {
+    const { data } = await axios.get(`${FINANCE_API_BASE}/subscriptions`, {
+      params: buildQueryParams(filters)
+    })
+
+    return mapSubscriptionMetrics(data)
   },
+
   async getCostMetrics(filters: FinancialFilters): Promise<CostMetrics> {
-    return aggregateCosts(filters)
+    const { data } = await axios.get(`${FINANCE_API_BASE}/costs`, {
+      params: buildQueryParams(filters)
+    })
+
+    return mapCostMetrics(data)
   },
+
   async getBusinessKpis(filters: FinancialFilters): Promise<BusinessKpi[]> {
-    return aggregateKpis(filters)
+    const { data } = await axios.get(`${FINANCE_API_BASE}/kpis`, {
+      params: buildQueryParams(filters)
+    })
+
+    return mapBusinessKpis(data)
   },
+
   async getCohortRetention(filters: FinancialFilters): Promise<CohortPoint[]> {
-    return filterCohorts(filters)
+    const { data } = await axios.get(`${FINANCE_API_BASE}/cohorts`, {
+      params: buildQueryParams(filters)
+    })
+
+    return mapCohorts(data)
   },
+
   async exportFinancialData(format: ExportFormat, filters: FinancialFilters): Promise<Blob> {
-    const payload = await getExportPayload(filters)
+    const { data } = await axios.get(`${FINANCE_API_BASE}/export`, {
+      params: { ...buildQueryParams(filters), format },
+      responseType: 'blob'
+    })
 
-    if (format === 'csv') {
-      const csv = createCsv(payload)
-      return createBlobWithFallback(csv, 'text/csv')
-    }
-
-    if (format === 'excel') {
-      const excel = createExcel(payload)
-      return createBlobWithFallback(excel, 'application/vnd.ms-excel')
-    }
-
-    const pdf = createPdf(payload)
-    return createBlobWithFallback(pdf, 'application/pdf')
+    return ensureBlob(data, format)
   }
 }
 
-export type { FinancialRecord }


### PR DESCRIPTION
## Summary
- replace local aggregations in the financial service with axios calls to `/api/finance/*` endpoints and normalize responses
- update FinancialDashboard and related widgets to handle async loading, errors, and dynamic plan lists from the API
- refresh the finance Vitest suite to stub HTTP requests and document the real backend usage in README and architecture docs

## Testing
- `npm run test:finance`


------
https://chatgpt.com/codex/tasks/task_e_68da18c0039483329ced33cfb1ebf0a1