### PR TITLE
Add alerting management UI and service with tests

### DIFF
--- a/src/__tests__/alerting.suite.test.tsx
+++ b/src/__tests__/alerting.suite.test.tsx
@@ -1,0 +1,411 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as matchers from '@testing-library/jest-dom/matchers'
+import { cleanup, render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import {
+  type MonitoringHistoryRange,
+  type MonitoringHistoryResponse,
+  type MonitoringMetricsResponse,
+  type MonitoringStatusResponse,
+  type MonitoringStreamsResponse,
+  MonitoringService
+} from '../services/monitoringService'
+import {
+  AlertingService,
+  type AlertRule,
+  type EscalationPolicy,
+  type NotificationChannel
+} from '../services/alertingService'
+import { SystemMonitoringDashboard } from '../components/monitoring/SystemMonitoringDashboard'
+import { createMockWebSocket } from './utils/networkMocks'
+import { AuthProvider } from '../hooks/usePermissions'
+import { AuthService } from '../services/authService'
+
+const monitoringWebSocketRef = vi.hoisted(() => ({
+  current: null as ReturnType<typeof createMockWebSocket>['controller'] | null
+}))
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value))
+
+let monitoringFixtures: {
+  metrics: MonitoringMetricsResponse
+  status: MonitoringStatusResponse
+  history: Record<MonitoringHistoryRange, MonitoringHistoryResponse>
+  streams: MonitoringStreamsResponse
+}
+
+let alertFixtures: {
+  rules: AlertRule[]
+  channels: NotificationChannel[]
+  escalations: EscalationPolicy[]
+}
+
+vi.mock('../services/monitoringService', async () => {
+  const actual = await vi.importActual<typeof import('../services/monitoringService')>(
+    '../services/monitoringService'
+  )
+
+  return {
+    ...actual,
+    MonitoringService: {
+      getMetrics: vi.fn(),
+      getStatus: vi.fn(),
+      getHistory: vi.fn(),
+      getStreams: vi.fn()
+    }
+  }
+})
+
+vi.mock('../services/alertingService', async () => {
+  const actual = await vi.importActual<typeof import('../services/alertingService')>(
+    '../services/alertingService'
+  )
+
+  return {
+    ...actual,
+    AlertingService: {
+      listRules: vi.fn(),
+      listChannels: vi.fn(),
+      listEscalationPolicies: vi.fn(),
+      createRule: vi.fn(),
+      updateRule: vi.fn()
+    }
+  }
+})
+
+vi.mock('../hooks/useWebSocket', async () => {
+  const { createMockWebSocket: factory } = await vi.importActual<
+    typeof import('./utils/networkMocks')
+  >('./utils/networkMocks')
+  const { module, controller } = factory()
+  monitoringWebSocketRef.current = controller
+  return module
+})
+
+vi.mock('../services/authService', async () => {
+  const actual = await vi.importActual<typeof import('../services/authService')>(
+    '../services/authService'
+  )
+  return {
+    ...actual,
+    AuthService: {
+      getSession: vi.fn(),
+      getPermissions: vi.fn()
+    }
+  }
+})
+
+expect.extend(matchers)
+
+const monitoringServiceMock = vi.mocked(MonitoringService)
+const alertingServiceMock = vi.mocked(AlertingService)
+const authServiceMock = vi.mocked(AuthService)
+
+describe('Alerting management', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:4000')
+    vi.stubEnv('VITE_WS_BASE_URL', 'ws://localhost:5000/ws')
+
+    monitoringFixtures = {
+      metrics: {
+        generatedAt: '2024-01-01T10:00:00.000Z',
+        services: [
+          {
+            id: 'auth-api',
+            name: 'Auth API',
+            description: "API d'authentification",
+            environment: 'production',
+            region: 'eu-west-1',
+            status: 'operational',
+            lastUpdatedAt: '2024-01-01T10:00:00.000Z',
+            indicators: [
+              {
+                type: 'cpu',
+                label: 'CPU',
+                unit: '%',
+                value: 42.5,
+                thresholds: { warning: 70, critical: 90 }
+              }
+            ]
+          }
+        ]
+      },
+      status: {
+        services: [
+          {
+            id: 'auth-api',
+            name: 'Auth API',
+            status: 'operational',
+            environment: 'production',
+            uptimePercentage: 99.9,
+            lastCheckedAt: '2024-01-01T10:00:00.000Z'
+          }
+        ],
+        incidents: [],
+        updatedAt: '2024-01-01T10:00:00.000Z'
+      },
+      history: {
+        '24h': {
+          range: '24h',
+          generatedAt: '2024-01-01T10:00:00.000Z',
+          series: []
+        },
+        '7d': {
+          range: '7d',
+          generatedAt: '2024-01-01T10:00:00.000Z',
+          series: []
+        },
+        '30d': {
+          range: '30d',
+          generatedAt: '2024-01-01T10:00:00.000Z',
+          series: []
+        }
+      },
+      streams: {
+        socketPath: '/ws/monitoring',
+        topics: []
+      }
+    }
+
+    alertFixtures = {
+      rules: [
+        {
+          id: 'rule-cpu-critical',
+          name: 'CPU critique',
+          description: 'Alerte critique sur la consommation CPU',
+          severity: 'critical',
+          enabled: true,
+          conditions: [
+            {
+              metric: 'cpu',
+              operator: 'gt',
+              threshold: 85,
+              window: { durationMinutes: 5, aggregation: 'avg' }
+            }
+          ],
+          channelIds: ['channel-email'],
+          escalation: {
+            steps: [{ delayMinutes: 10, channelIds: ['channel-sms'] }],
+            repeat: false
+          },
+          createdAt: '2024-01-01T08:00:00.000Z',
+          updatedAt: '2024-01-01T09:00:00.000Z'
+        }
+      ],
+      channels: [
+        { id: 'channel-email', name: 'Astreinte', type: 'email', target: 'oncall@meetinity.test' },
+        { id: 'channel-slack', name: 'On-call', type: 'slack', target: '#oncall-alerts' },
+        { id: 'channel-sms', name: 'Escalade SMS', type: 'sms', target: '+33123456789' }
+      ],
+      escalations: [
+        {
+          id: 'policy-critical',
+          name: 'Escalade critique',
+          description: 'Prévenir le N2 puis le manager au bout de 30 minutes.',
+          repeat: true,
+          steps: [
+            { delayMinutes: 0, channelIds: ['channel-email'] },
+            { delayMinutes: 15, channelIds: ['channel-slack'] }
+          ],
+          createdAt: '2023-12-01T10:00:00.000Z',
+          updatedAt: '2023-12-10T10:00:00.000Z'
+        }
+      ]
+    }
+
+    monitoringServiceMock.getMetrics.mockImplementation(() => Promise.resolve(clone(monitoringFixtures.metrics)))
+    monitoringServiceMock.getStatus.mockImplementation(() => Promise.resolve(clone(monitoringFixtures.status)))
+    monitoringServiceMock.getHistory.mockImplementation(({ range }: { range: MonitoringHistoryRange }) =>
+      Promise.resolve(clone(monitoringFixtures.history[range]))
+    )
+    monitoringServiceMock.getStreams.mockImplementation(() => Promise.resolve(clone(monitoringFixtures.streams)))
+
+    alertingServiceMock.listRules.mockImplementation(() => Promise.resolve(clone(alertFixtures.rules)))
+    alertingServiceMock.listChannels.mockImplementation(() => Promise.resolve(clone(alertFixtures.channels)))
+    alertingServiceMock.listEscalationPolicies.mockImplementation(() =>
+      Promise.resolve(clone(alertFixtures.escalations))
+    )
+    alertingServiceMock.createRule.mockImplementation(async input => ({
+      id: 'rule-created',
+      name: input.name,
+      description: input.description,
+      severity: input.severity,
+      enabled: input.enabled,
+      conditions: input.conditions,
+      channelIds: input.channelIds,
+      escalation: input.escalation ?? null,
+      createdAt: '2024-01-01T11:00:00.000Z',
+      updatedAt: '2024-01-01T11:00:00.000Z'
+    }))
+    alertingServiceMock.updateRule.mockImplementation(async (ruleId, input) => ({
+      id: ruleId,
+      name: input.name,
+      description: input.description,
+      severity: input.severity,
+      enabled: input.enabled,
+      conditions: input.conditions,
+      channelIds: input.channelIds,
+      escalation: input.escalation ?? null,
+      createdAt: '2024-01-01T08:00:00.000Z',
+      updatedAt: '2024-01-01T12:00:00.000Z'
+    }))
+
+    authServiceMock.getSession.mockResolvedValue({
+      id: 'admin-1',
+      email: 'ops@meetinity.test',
+      name: 'Ops Admin',
+      role: 'super-admin'
+    })
+    authServiceMock.getPermissions.mockResolvedValue({
+      permissions: ['admin:access', 'monitoring:read', 'monitoring:manage'],
+      roles: ['operations']
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    monitoringWebSocketRef.current?.reset()
+    vi.unstubAllEnvs()
+  })
+
+  it('crée une règle personnalisée avec escalade multi-canaux', async () => {
+    alertFixtures.rules = []
+    alertFixtures.escalations = []
+
+    render(
+      <AuthProvider>
+        <SystemMonitoringDashboard />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(authServiceMock.getPermissions).toHaveBeenCalled())
+
+
+    const [alertsTab] = screen.getAllByRole('tab', { name: 'Alertes' })
+    fireEvent.click(alertsTab)
+
+    await waitFor(() => expect(alertingServiceMock.listRules).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('Nom de la règle'), { target: { value: 'CPU critique' } })
+    const metricSelectCreate = await screen.findByLabelText('Métrique surveillée')
+    await waitFor(() => expect(metricSelectCreate).not.toBeDisabled())
+    fireEvent.change(metricSelectCreate, { target: { value: 'cpu' } })
+    fireEvent.change(screen.getByLabelText(/Seuil/), { target: { value: '80' } })
+    fireEvent.change(screen.getByLabelText('Fenêtre glissante (minutes)'), { target: { value: '5' } })
+
+    const ruleChannels = screen.getByRole('group', { name: 'Canaux de notification' })
+    fireEvent.click(within(ruleChannels).getByLabelText(/Email — Astreinte/))
+    fireEvent.click(within(ruleChannels).getByLabelText(/Slack — On-call/))
+
+    const firstStep = screen.getByTestId('escalation-step-0')
+    fireEvent.change(within(firstStep).getByLabelText("Délai avant l'étape 1 (minutes)"), {
+      target: { value: '10' }
+    })
+    const stepChannels = within(firstStep).getByRole('group', { name: 'Canaux pour cette étape' })
+    fireEvent.click(within(stepChannels).getByLabelText(/Email — Astreinte/))
+    fireEvent.click(within(stepChannels).getByLabelText(/Slack — On-call/))
+
+    const saveButtonCreate = await screen.findByRole('button', { name: 'Sauvegarder la règle' })
+    await waitFor(() => expect(saveButtonCreate).not.toBeDisabled())
+    fireEvent.click(saveButtonCreate)
+
+    await waitFor(() => expect(alertingServiceMock.createRule).toHaveBeenCalledTimes(1))
+
+    const [payload] = alertingServiceMock.createRule.mock.calls[0]
+    expect(payload.name).toBe('CPU critique')
+    expect(payload.channelIds).toEqual(expect.arrayContaining(['channel-email', 'channel-slack']))
+    expect(payload.escalation?.steps?.[0].delayMinutes).toBe(10)
+    expect(payload.escalation?.steps?.[0].channelIds).toEqual(
+      expect.arrayContaining(['channel-email', 'channel-slack'])
+    )
+
+    await screen.findByText('Règle « CPU critique » créée.')
+    await screen.findByText('CPU critique')
+  })
+
+  it('met à jour une règle existante et applique un nouveau seuil', async () => {
+    render(
+      <AuthProvider>
+        <SystemMonitoringDashboard />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(authServiceMock.getPermissions).toHaveBeenCalled())
+
+    const [alertsTab] = screen.getAllByRole('tab', { name: 'Alertes' })
+    fireEvent.click(alertsTab)
+
+    await waitFor(() => expect(alertingServiceMock.listRules).toHaveBeenCalled())
+
+    const ruleSelector = await screen.findByRole('button', { name: /CPU critique/ })
+    fireEvent.click(ruleSelector)
+
+    await screen.findByText('Modifier la règle « CPU critique »')
+
+    const metricSelectUpdate = await screen.findByLabelText('Métrique surveillée')
+    await waitFor(() => expect(metricSelectUpdate).not.toBeDisabled())
+
+    const ruleChannelsGroup = screen.getByRole('group', { name: 'Canaux de notification' })
+    const slackChannel = within(ruleChannelsGroup).getByLabelText(/Slack — On-call/) as HTMLInputElement
+    await waitFor(() => expect(slackChannel).not.toBeDisabled())
+    if (!slackChannel.checked) {
+      fireEvent.click(slackChannel)
+    }
+
+    const thresholdInput = await screen.findByLabelText(/Seuil/)
+    fireEvent.change(thresholdInput, { target: { value: '90' } })
+
+    const saveButtonUpdate = await screen.findByRole('button', { name: 'Sauvegarder la règle' })
+    await waitFor(() => expect(saveButtonUpdate).not.toBeDisabled())
+    const updateForm = saveButtonUpdate.closest('form')
+    expect(updateForm).not.toBeNull()
+    fireEvent.submit(updateForm as HTMLFormElement)
+
+    await waitFor(() => expect(alertingServiceMock.updateRule).toHaveBeenCalledTimes(1))
+
+    const [ruleId, payload] = alertingServiceMock.updateRule.mock.calls[0]
+    expect(ruleId).toBe('rule-cpu-critical')
+    expect(payload.conditions[0].threshold).toBe(90)
+    await screen.findByText('Règle « CPU critique » mise à jour.')
+  })
+
+  it('permet de sélectionner une politique d’escalade existante', async () => {
+    alertFixtures.rules = []
+
+    render(
+      <AuthProvider>
+        <SystemMonitoringDashboard />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(authServiceMock.getPermissions).toHaveBeenCalled())
+    const [alertsTab] = screen.getAllByRole('tab', { name: 'Alertes' })
+    fireEvent.click(alertsTab)
+
+    await waitFor(() => expect(alertingServiceMock.listRules).toHaveBeenCalled())
+    await waitFor(() => expect(alertingServiceMock.listEscalationPolicies).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('Nom de la règle'), { target: { value: 'Latence élevée' } })
+    const metricSelectPolicy = await screen.findByLabelText('Métrique surveillée')
+    await waitFor(() => expect(metricSelectPolicy).not.toBeDisabled())
+    fireEvent.change(metricSelectPolicy, { target: { value: 'cpu' } })
+    fireEvent.change(screen.getByLabelText(/Seuil/), { target: { value: '75' } })
+    fireEvent.change(screen.getByLabelText('Fenêtre glissante (minutes)'), { target: { value: '3' } })
+
+    const ruleChannels = screen.getByRole('group', { name: 'Canaux de notification' })
+    fireEvent.click(within(ruleChannels).getByLabelText(/SMS — Escalade SMS/))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sauvegarder la règle' }))
+
+    await waitFor(() => expect(alertingServiceMock.createRule).toHaveBeenCalledTimes(1))
+
+    const [payload] = alertingServiceMock.createRule.mock.calls[0]
+    expect(payload.escalation).toEqual({ policyId: 'policy-critical', repeat: true })
+    await screen.findByText('Règle « Latence élevée » créée.')
+  })
+})
+

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -36,7 +36,12 @@ function RequirePermissions({ children, requiredPermissions = [] }: RequirePermi
   }
 
   if (!hasPermissions(requiredPermissions)) {
-    return <Navigate to="/unauthorized" replace />
+    const missingPermissions = requiredPermissions.filter(permission => !hasPermissions([permission]))
+    const requiresMonitoringManage = missingPermissions.includes('monitoring:manage')
+    const message = requiresMonitoringManage
+      ? "Vous avez besoin de la permission « monitoring:manage » pour gérer les alertes et les politiques d'escalade."
+      : undefined
+    return <Navigate to="/unauthorized" replace state={message ? { message } : undefined} />
   }
 
   return children

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -65,6 +65,7 @@ const breadcrumbNavStyle: React.CSSProperties = {
 export function AdminLayout() {
   const location = useLocation()
   const { admin, hasPermissions } = usePermissions()
+  const canManageMonitoring = useMemo(() => hasPermissions(['monitoring:manage']), [hasPermissions])
 
   const availableModules = useMemo(
     () => ADMIN_MODULES.filter(module => hasPermissions(module.requiredPermissions)),
@@ -90,6 +91,8 @@ export function AdminLayout() {
       return { path: currentPath, label }
     })
   }, [labelMap, location.pathname])
+
+  const outletContext = useMemo(() => ({ canManageMonitoring }), [canManageMonitoring])
 
   return (
     <div style={layoutStyle}>
@@ -130,8 +133,11 @@ export function AdminLayout() {
             <div style={{ fontSize: '0.875rem', color: '#6b7280' }}>{admin?.email}</div>
           </div>
         </header>
-        <main style={contentStyle}>
-          <Outlet />
+        <main
+          style={contentStyle}
+          data-can-manage-monitoring={canManageMonitoring ? 'true' : 'false'}
+        >
+          <Outlet context={outletContext} />
         </main>
       </div>
     </div>

--- a/src/components/monitoring/AlertRuleBuilder.tsx
+++ b/src/components/monitoring/AlertRuleBuilder.tsx
@@ -1,0 +1,599 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  type AlertCondition,
+  type AlertRule,
+  type AlertRuleInput,
+  type NotificationChannel,
+  type EscalationPolicy,
+  type RuleEscalationConfig,
+  type EscalationStep,
+  AlertWindowAggregation
+} from '../../services/alertingService'
+import { NotificationChannelPicker } from './NotificationChannelPicker'
+import { EscalationPolicyEditor, type EscalationDraft } from './EscalationPolicyEditor'
+
+export interface AlertMetricOption {
+  id: string
+  label: string
+  unit?: string
+}
+
+interface AlertRuleBuilderProps {
+  rule?: AlertRule | null
+  metrics: AlertMetricOption[]
+  channels: NotificationChannel[]
+  escalationPolicies: EscalationPolicy[]
+  onSave: (input: AlertRuleInput) => Promise<void>
+  canManage: boolean
+  isSaving: boolean
+  error?: string | null
+  successMessage?: string | null
+}
+
+const OPERATOR_LABELS: Record<AlertCondition['operator'], string> = {
+  gt: '>',
+  gte: '≥',
+  lt: '<',
+  lte: '≤',
+  eq: '=',
+  neq: '≠'
+}
+
+const AGGREGATION_LABELS: Record<AlertWindowAggregation, string> = {
+  avg: 'Moyenne',
+  max: 'Maximum',
+  min: 'Minimum',
+  sum: 'Somme'
+}
+
+interface ConditionFormState {
+  metric: string
+  operator: AlertCondition['operator']
+  threshold: string
+  windowMinutes: string
+  aggregation: AlertWindowAggregation
+}
+
+const DEFAULT_CONDITION_STATE: ConditionFormState = {
+  metric: '',
+  operator: 'gt',
+  threshold: '',
+  windowMinutes: '5',
+  aggregation: 'avg'
+}
+
+const createDefaultEscalation = (): EscalationDraft => ({
+  mode: 'custom',
+  steps: [{ delayMinutes: 0, channelIds: [] }],
+  repeat: false
+})
+
+export function AlertRuleBuilder({
+  rule,
+  metrics,
+  channels,
+  escalationPolicies,
+  onSave,
+  canManage,
+  isSaving,
+  error,
+  successMessage
+}: AlertRuleBuilderProps) {
+  const [name, setName] = useState(rule?.name ?? '')
+  const [description, setDescription] = useState(rule?.description ?? '')
+  const [severity, setSeverity] = useState<'warning' | 'critical'>(rule?.severity ?? 'warning')
+  const [enabled, setEnabled] = useState<boolean>(rule?.enabled ?? true)
+  const [condition, setCondition] = useState<ConditionFormState>(DEFAULT_CONDITION_STATE)
+  const [selectedChannels, setSelectedChannels] = useState<string[]>(rule?.channelIds ?? [])
+  const [escalation, setEscalation] = useState<EscalationDraft>(() => createDefaultEscalation())
+  const [validationErrors, setValidationErrors] = useState<string[]>([])
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!rule) {
+      setName('')
+      setDescription('')
+      setSeverity('warning')
+      setEnabled(true)
+      setCondition(prev => ({
+        ...DEFAULT_CONDITION_STATE,
+        metric: metrics[0]?.id ?? prev.metric
+      }))
+      setSelectedChannels([])
+      setEscalation(
+        escalationPolicies.length > 0
+          ? {
+              mode: 'existing',
+              policyId: escalationPolicies[0].id,
+              steps: [],
+              repeat: escalationPolicies[0].repeat ?? false
+            }
+          : createDefaultEscalation()
+      )
+      return
+    }
+
+    const ruleCondition = rule.conditions[0]
+    setName(rule.name)
+    setDescription(rule.description ?? '')
+    setSeverity(rule.severity)
+    setEnabled(rule.enabled)
+    setCondition({
+      metric: ruleCondition?.metric ?? metrics[0]?.id ?? '',
+      operator: ruleCondition?.operator ?? 'gt',
+      threshold: ruleCondition?.threshold != null ? String(ruleCondition.threshold) : '',
+      windowMinutes:
+        ruleCondition?.window?.durationMinutes != null
+          ? String(ruleCondition.window.durationMinutes)
+          : DEFAULT_CONDITION_STATE.windowMinutes,
+      aggregation: ruleCondition?.window?.aggregation ?? 'avg'
+    })
+    setSelectedChannels(rule.channelIds)
+    setEscalation(() => {
+      const base = rule.escalation
+      if (!base) {
+        return escalationPolicies.length > 0
+          ? {
+              mode: 'existing',
+              policyId: escalationPolicies[0].id,
+              steps: [],
+              repeat: escalationPolicies[0].repeat ?? false
+            }
+          : createDefaultEscalation()
+      }
+
+      if (base.policyId) {
+        const policy = escalationPolicies.find(item => item.id === base.policyId)
+        return {
+          mode: 'existing',
+          policyId: base.policyId,
+          steps: [],
+          repeat: base.repeat ?? policy?.repeat ?? false
+        }
+      }
+
+      return {
+        mode: 'custom',
+        steps:
+          base.steps && base.steps.length > 0
+            ? base.steps
+            : createDefaultEscalation().steps,
+        repeat: base.repeat ?? false
+      }
+  })
+  }, [rule, metrics, escalationPolicies])
+
+  useEffect(() => {
+    setLocalError(null)
+  }, [rule])
+
+  const currentMetricOptions = useMemo(() => metrics, [metrics])
+
+  useEffect(() => {
+    if (condition.metric || currentMetricOptions.length === 0) {
+      return
+    }
+    setCondition(prev => ({ ...prev, metric: currentMetricOptions[0]?.id ?? '' }))
+  }, [condition.metric, currentMetricOptions])
+
+  const handleAggregationChange = (aggregation: AlertWindowAggregation) => {
+    setCondition(prev => ({ ...prev, aggregation }))
+  }
+
+  const handleOperatorChange = (operator: AlertCondition['operator']) => {
+    setCondition(prev => ({ ...prev, operator }))
+  }
+
+  const mapFormToCondition = (): AlertCondition | null => {
+    const metricOption = currentMetricOptions.find(option => option.id === condition.metric)
+    if (!metricOption) {
+      return null
+    }
+
+    const threshold = Number.parseFloat(condition.threshold)
+    const windowMinutes = Number.parseInt(condition.windowMinutes, 10)
+
+    if (Number.isNaN(threshold) || Number.isNaN(windowMinutes) || windowMinutes <= 0) {
+      return null
+    }
+
+    return {
+      metric: metricOption.id,
+      operator: condition.operator,
+      threshold,
+      window: {
+        durationMinutes: windowMinutes,
+        aggregation: condition.aggregation
+      }
+    }
+  }
+
+  const validateForm = (): boolean => {
+    const errors: string[] = []
+
+    if (!name.trim()) {
+      errors.push('Le nom de la règle est requis.')
+    }
+
+    if (!condition.metric) {
+      errors.push('Sélectionnez une métrique pour surveiller la condition.')
+    }
+
+    const threshold = Number.parseFloat(condition.threshold)
+    if (Number.isNaN(threshold)) {
+      errors.push('Le seuil doit être un nombre valide.')
+    }
+
+    const windowMinutes = Number.parseInt(condition.windowMinutes, 10)
+    if (Number.isNaN(windowMinutes) || windowMinutes <= 0) {
+      errors.push('La fenêtre glissante doit être supérieure à zéro.')
+    }
+
+    if (selectedChannels.length === 0) {
+      errors.push('Sélectionnez au moins un canal de notification.')
+    }
+
+    if (escalation.mode === 'existing' && !escalation.policyId) {
+      errors.push("Choisissez une politique d'escalade existante ou personnalisez la séquence.")
+    }
+
+    if (escalation.mode === 'custom') {
+      const invalidStep = escalation.steps.some(step => step.channelIds.length === 0)
+      if (escalation.steps.length === 0 || invalidStep) {
+        errors.push('Chaque étape personnalisée doit notifier au moins un canal.')
+      }
+    }
+
+    setValidationErrors(errors)
+    return errors.length === 0
+  }
+
+  const buildEscalationPayload = (): RuleEscalationConfig | null => {
+    if (escalation.mode === 'existing') {
+      return escalation.policyId ? { policyId: escalation.policyId, repeat: escalation.repeat } : null
+    }
+
+    const steps: EscalationStep[] = escalation.steps.map(step => ({
+      delayMinutes: step.delayMinutes,
+      channelIds: step.channelIds
+    }))
+
+    return {
+      steps,
+      repeat: escalation.repeat
+    }
+  }
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async event => {
+    event.preventDefault()
+
+    if (!canManage) {
+      setLocalError("Vous n'avez pas l'autorisation de modifier les alertes.")
+      return
+    }
+
+    setLocalError(null)
+
+    if (!validateForm()) {
+      return
+    }
+
+    const conditionPayload = mapFormToCondition()
+    if (!conditionPayload) {
+      setLocalError('Les paramètres de la condition sont invalides.')
+      return
+    }
+
+    const payload: AlertRuleInput = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      severity,
+      enabled,
+      conditions: [conditionPayload],
+      channelIds: selectedChannels,
+      escalation: buildEscalationPayload()
+    }
+
+    try {
+      await onSave(payload)
+      setValidationErrors([])
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "La sauvegarde de la règle a échoué."
+      setLocalError(message)
+    }
+  }
+
+  const currentMetricLabel = useMemo(() => {
+    const option = currentMetricOptions.find(item => item.id === condition.metric)
+    if (!option || !option.unit) {
+      return null
+    }
+    return option.unit
+  }, [condition.metric, currentMetricOptions])
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <h2 style={{ margin: 0, fontSize: '1.5rem' }}>
+          {rule ? `Modifier la règle « ${rule.name} »` : 'Créer une règle d\'alerte'}
+        </h2>
+        <p style={{ margin: 0, color: '#64748b', fontSize: '0.95rem' }}>
+          Définissez une condition de déclenchement et les canaux de notification correspondants.
+        </p>
+      </header>
+
+      {successMessage && (
+        <div
+          role="status"
+          style={{
+            backgroundColor: 'rgba(34,197,94,0.12)',
+            border: '1px solid rgba(34,197,94,0.35)',
+            color: '#0f5132',
+            padding: '12px 16px',
+            borderRadius: '10px'
+          }}
+        >
+          {successMessage}
+        </div>
+      )}
+
+      {(error || localError) && (
+        <div
+          role="alert"
+          style={{
+            backgroundColor: 'rgba(248,113,113,0.12)',
+            border: '1px solid rgba(248,113,113,0.35)',
+            color: '#991b1b',
+            padding: '12px 16px',
+            borderRadius: '10px'
+          }}
+        >
+          {localError || error}
+        </div>
+      )}
+
+      {validationErrors.length > 0 && (
+        <ul style={{ margin: 0, paddingLeft: '20px', color: '#b91c1c', fontSize: '0.9rem' }}>
+          {validationErrors.map(item => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      )}
+
+      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '16px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <label htmlFor="alert-rule-name" style={{ fontWeight: 600 }}>
+            Nom de la règle
+          </label>
+          <input
+            id="alert-rule-name"
+            type="text"
+            value={name}
+            onChange={event => setName(event.target.value)}
+            disabled={!canManage}
+            style={{
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid #cbd5f5',
+              fontSize: '0.95rem'
+            }}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <label htmlFor="alert-rule-severity" style={{ fontWeight: 600 }}>
+            Sévérité
+          </label>
+          <div id="alert-rule-severity" style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <input
+                type="radio"
+                name="alert-rule-severity"
+                value="warning"
+                checked={severity === 'warning'}
+                onChange={() => setSeverity('warning')}
+                disabled={!canManage}
+              />
+              Avertissement
+            </label>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <input
+                type="radio"
+                name="alert-rule-severity"
+                value="critical"
+                checked={severity === 'critical'}
+                onChange={() => setSeverity('critical')}
+                disabled={!canManage}
+              />
+              Critique
+            </label>
+          </div>
+        </div>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontWeight: 600 }}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={event => setEnabled(event.target.checked)}
+            disabled={!canManage}
+          />
+          Activer la règle
+        </label>
+      </section>
+
+      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '16px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <label htmlFor="alert-rule-description" style={{ fontWeight: 600 }}>
+            Description (facultatif)
+          </label>
+          <textarea
+            id="alert-rule-description"
+            value={description}
+            onChange={event => setDescription(event.target.value)}
+            disabled={!canManage}
+            rows={3}
+            style={{
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid #cbd5f5',
+              fontSize: '0.95rem',
+              resize: 'vertical'
+            }}
+          />
+        </div>
+      </section>
+
+      <section
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+          gap: '16px',
+          border: '1px solid #e2e8f0',
+          borderRadius: '12px',
+          padding: '16px'
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <label htmlFor="alert-condition-metric" style={{ fontWeight: 600 }}>
+            Métrique surveillée
+          </label>
+          <select
+            id="alert-condition-metric"
+            value={condition.metric}
+            onChange={event => setCondition(prev => ({ ...prev, metric: event.target.value }))}
+            disabled={!canManage || currentMetricOptions.length === 0}
+            style={{
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid #cbd5f5',
+              fontSize: '0.95rem'
+            }}
+          >
+            {currentMetricOptions.length === 0 && <option value="">Aucune métrique disponible</option>}
+            {currentMetricOptions.map(option => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <label htmlFor="alert-condition-operator" style={{ fontWeight: 600 }}>
+            Opérateur
+          </label>
+          <select
+            id="alert-condition-operator"
+            value={condition.operator}
+            onChange={event => handleOperatorChange(event.target.value as AlertCondition['operator'])}
+            disabled={!canManage}
+            style={{
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid #cbd5f5',
+              fontSize: '0.95rem'
+            }}
+          >
+            {Object.entries(OPERATOR_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <label htmlFor="alert-condition-threshold" style={{ fontWeight: 600 }}>
+            Seuil {currentMetricLabel ? `(${currentMetricLabel})` : ''}
+          </label>
+          <input
+            id="alert-condition-threshold"
+            type="number"
+            value={condition.threshold}
+            onChange={event => setCondition(prev => ({ ...prev, threshold: event.target.value }))}
+            disabled={!canManage}
+            style={{
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid #cbd5f5',
+              fontSize: '0.95rem'
+            }}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <label htmlFor="alert-condition-window" style={{ fontWeight: 600 }}>
+            Fenêtre glissante (minutes)
+          </label>
+          <input
+            id="alert-condition-window"
+            type="number"
+            min={1}
+            value={condition.windowMinutes}
+            onChange={event => setCondition(prev => ({ ...prev, windowMinutes: event.target.value }))}
+            disabled={!canManage}
+            style={{
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid #cbd5f5',
+              fontSize: '0.95rem'
+            }}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <label htmlFor="alert-condition-aggregation" style={{ fontWeight: 600 }}>
+            Agrégation
+          </label>
+          <select
+            id="alert-condition-aggregation"
+            value={condition.aggregation}
+            onChange={event => handleAggregationChange(event.target.value as AlertWindowAggregation)}
+            disabled={!canManage}
+            style={{
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid #cbd5f5',
+              fontSize: '0.95rem'
+            }}
+          >
+            {Object.entries(AGGREGATION_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </section>
+
+      <NotificationChannelPicker
+        channels={channels}
+        selectedChannelIds={selectedChannels}
+        onChange={setSelectedChannels}
+        disabled={!canManage}
+      />
+
+      <EscalationPolicyEditor
+        channels={channels}
+        availablePolicies={escalationPolicies}
+        value={escalation}
+        onChange={draft => setEscalation(draft)}
+        disabled={!canManage}
+      />
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          type="submit"
+          disabled={!canManage || isSaving}
+          style={{
+            padding: '12px 18px',
+            borderRadius: '10px',
+            border: 'none',
+            backgroundColor: !canManage ? '#94a3b8' : '#2563eb',
+            color: '#fff',
+            fontWeight: 600,
+            cursor: !canManage || isSaving ? 'not-allowed' : 'pointer',
+            minWidth: '220px'
+          }}
+        >
+          {isSaving ? 'Sauvegarde en cours...' : 'Sauvegarder la règle'}
+        </button>
+      </div>
+    </form>
+  )
+}
+

--- a/src/components/monitoring/EscalationPolicyEditor.tsx
+++ b/src/components/monitoring/EscalationPolicyEditor.tsx
@@ -1,0 +1,285 @@
+import React from 'react'
+import {
+  type EscalationPolicy,
+  type EscalationStep,
+  type NotificationChannel
+} from '../../services/alertingService'
+import { NotificationChannelPicker } from './NotificationChannelPicker'
+
+export type EscalationEditorMode = 'existing' | 'custom'
+
+export interface EscalationDraft {
+  mode: EscalationEditorMode
+  policyId?: string
+  steps: EscalationStep[]
+  repeat?: boolean
+}
+
+interface EscalationPolicyEditorProps {
+  channels: NotificationChannel[]
+  availablePolicies: EscalationPolicy[]
+  value: EscalationDraft
+  onChange: (draft: EscalationDraft) => void
+  disabled?: boolean
+}
+
+const DEFAULT_STEP: EscalationStep = { delayMinutes: 0, channelIds: [] }
+
+export function EscalationPolicyEditor({
+  channels,
+  availablePolicies,
+  value,
+  onChange,
+  disabled
+}: EscalationPolicyEditorProps) {
+  const handleModeChange = (mode: EscalationEditorMode) => {
+    if (disabled) {
+      return
+    }
+
+    if (mode === 'existing') {
+      const firstPolicy = value.policyId
+        ? availablePolicies.find(policy => policy.id === value.policyId)
+        : availablePolicies[0]
+      onChange({
+        mode,
+        policyId: firstPolicy?.id,
+        steps: [],
+        repeat: firstPolicy?.repeat ?? false
+      })
+      return
+    }
+
+    onChange({
+      mode,
+      policyId: undefined,
+      steps: value.steps.length > 0 ? value.steps : [DEFAULT_STEP],
+      repeat: value.repeat ?? false
+    })
+  }
+
+  const handlePolicyChange = (policyId: string) => {
+    if (disabled) {
+      return
+    }
+
+    const policy = availablePolicies.find(item => item.id === policyId)
+    onChange({
+      mode: 'existing',
+      policyId,
+      steps: [],
+      repeat: policy?.repeat ?? false
+    })
+  }
+
+  const handleStepChange = (index: number, step: EscalationStep) => {
+    if (disabled) {
+      return
+    }
+
+    const nextSteps = value.steps.map((current, idx) => (idx === index ? step : current))
+    onChange({ ...value, steps: nextSteps })
+  }
+
+  const handleAddStep = () => {
+    if (disabled) {
+      return
+    }
+
+    const nextDelay = value.steps.length > 0 ? value.steps[value.steps.length - 1].delayMinutes + 5 : 5
+    onChange({ ...value, steps: [...value.steps, { delayMinutes: nextDelay, channelIds: [] }] })
+  }
+
+  const handleRemoveStep = (index: number) => {
+    if (disabled) {
+      return
+    }
+
+    const nextSteps = value.steps.filter((_, idx) => idx !== index)
+    onChange({ ...value, steps: nextSteps.length > 0 ? nextSteps : [DEFAULT_STEP] })
+  }
+
+  const handleRepeatChange = (repeat: boolean) => {
+    if (disabled) {
+      return
+    }
+
+    onChange({ ...value, repeat })
+  }
+
+  return (
+    <section
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        border: '1px solid #e2e8f0',
+        borderRadius: '12px',
+        padding: '16px'
+      }}
+    >
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <h3 style={{ margin: 0, fontSize: '1.05rem' }}>Politique d'escalade</h3>
+        <p style={{ margin: 0, color: '#64748b', fontSize: '0.875rem' }}>
+          Définissez la séquence de notifications envoyées lorsque la condition persiste.
+        </p>
+      </header>
+
+      <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <input
+            type="radio"
+            name="escalation-mode"
+            value="custom"
+            checked={value.mode === 'custom'}
+            onChange={() => handleModeChange('custom')}
+            disabled={disabled}
+          />
+          Personnaliser la politique
+        </label>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <input
+            type="radio"
+            name="escalation-mode"
+            value="existing"
+            checked={value.mode === 'existing'}
+            onChange={() => handleModeChange('existing')}
+            disabled={disabled || availablePolicies.length === 0}
+          />
+          Utiliser une politique existante
+        </label>
+      </div>
+
+      {value.mode === 'existing' ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <label htmlFor="escalation-policy-select" style={{ fontWeight: 600 }}>
+            Politique d'escalade
+          </label>
+          <select
+            id="escalation-policy-select"
+            value={value.policyId ?? ''}
+            onChange={event => handlePolicyChange(event.target.value)}
+            disabled={disabled || availablePolicies.length === 0}
+            style={{
+              padding: '10px 12px',
+              borderRadius: '10px',
+              border: '1px solid #cbd5f5',
+              fontSize: '0.95rem'
+            }}
+          >
+            <option value="" disabled>
+              {availablePolicies.length === 0
+                ? 'Aucune politique disponible'
+                : 'Sélectionner une politique'}
+            </option>
+            {availablePolicies.map(policy => (
+              <option key={policy.id} value={policy.id}>
+                {policy.name}
+              </option>
+            ))}
+          </select>
+          {value.policyId && (
+            <p style={{ margin: 0, color: '#475569', fontSize: '0.875rem' }}>
+              {availablePolicies.find(policy => policy.id === value.policyId)?.description ??
+                'Les notifications suivront la configuration existante.'}
+            </p>
+          )}
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+          {value.steps.map((step, index) => (
+            <div
+              key={index}
+              data-testid={`escalation-step-${index}`}
+              style={{
+                border: '1px solid #e2e8f0',
+                borderRadius: '12px',
+                padding: '16px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '12px'
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <h4 style={{ margin: 0, fontSize: '1rem' }}>Étape {index + 1}</h4>
+                {value.steps.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveStep(index)}
+                    disabled={disabled}
+                    style={{
+                      border: 'none',
+                      background: 'transparent',
+                      color: '#ef4444',
+                      cursor: disabled ? 'not-allowed' : 'pointer'
+                    }}
+                  >
+                    Supprimer
+                  </button>
+                )}
+              </div>
+
+              <label htmlFor={`escalation-delay-${index}`} style={{ fontWeight: 600 }}>
+                Délai avant l'étape {index + 1} (minutes)
+              </label>
+              <input
+                id={`escalation-delay-${index}`}
+                type="number"
+                min={0}
+                value={step.delayMinutes}
+                onChange={event =>
+                  handleStepChange(index, {
+                    ...step,
+                    delayMinutes: Number.parseInt(event.target.value, 10) || 0
+                  })
+                }
+                disabled={disabled}
+                style={{
+                  padding: '10px 12px',
+                  border: '1px solid #cbd5f5',
+                  borderRadius: '10px',
+                  fontSize: '0.95rem'
+                }}
+              />
+
+              <NotificationChannelPicker
+                legend="Canaux pour cette étape"
+                channels={channels}
+                selectedChannelIds={step.channelIds}
+                onChange={channelIds => handleStepChange(index, { ...step, channelIds })}
+                disabled={disabled}
+                idPrefix={`escalation-step-${index}-channel`}
+              />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={handleAddStep}
+            disabled={disabled}
+            style={{
+              alignSelf: 'flex-start',
+              padding: '10px 14px',
+              borderRadius: '10px',
+              border: '1px dashed #2563eb',
+              backgroundColor: 'transparent',
+              color: '#2563eb',
+              cursor: disabled ? 'not-allowed' : 'pointer'
+            }}
+          >
+            Ajouter une étape
+          </button>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <input
+              type="checkbox"
+              checked={Boolean(value.repeat)}
+              onChange={event => handleRepeatChange(event.target.checked)}
+              disabled={disabled}
+            />
+            Répéter la séquence tant que l'incident est actif
+          </label>
+        </div>
+      )}
+    </section>
+  )
+}
+

--- a/src/components/monitoring/NotificationChannelPicker.tsx
+++ b/src/components/monitoring/NotificationChannelPicker.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import {
+  type NotificationChannel,
+  NOTIFICATION_CHANNEL_TYPE_LABELS
+} from '../../services/alertingService'
+
+interface NotificationChannelPickerProps {
+  legend?: string
+  channels: NotificationChannel[]
+  selectedChannelIds: string[]
+  onChange: (nextSelection: string[]) => void
+  disabled?: boolean
+  idPrefix?: string
+}
+
+export function NotificationChannelPicker({
+  legend = 'Canaux de notification',
+  channels,
+  selectedChannelIds,
+  onChange,
+  disabled,
+  idPrefix = 'alert-channel'
+}: NotificationChannelPickerProps) {
+  const handleToggle = (channelId: string) => {
+    if (disabled) {
+      return
+    }
+
+    const isSelected = selectedChannelIds.includes(channelId)
+    if (isSelected) {
+      onChange(selectedChannelIds.filter(id => id !== channelId))
+      return
+    }
+
+    onChange([...selectedChannelIds, channelId])
+  }
+
+  return (
+    <fieldset
+      style={{
+        border: '1px solid #e2e8f0',
+        borderRadius: '12px',
+        padding: '16px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px'
+      }}
+    >
+      <legend style={{ fontWeight: 600, fontSize: '0.95rem' }}>{legend}</legend>
+      {channels.length === 0 ? (
+        <p style={{ margin: 0, color: '#64748b', fontSize: '0.875rem' }}>
+          Aucun canal n'est disponible pour le moment.
+        </p>
+      ) : (
+        channels.map(channel => {
+          const isSelected = selectedChannelIds.includes(channel.id)
+          const label = `${NOTIFICATION_CHANNEL_TYPE_LABELS[channel.type]} — ${channel.name}`
+          const inputId = `${idPrefix}-${channel.id}`
+          return (
+            <label
+              key={channel.id}
+              htmlFor={inputId}
+              style={{
+                display: 'flex',
+                gap: '12px',
+                alignItems: 'center',
+                padding: '8px 10px',
+                borderRadius: '10px',
+                backgroundColor: isSelected ? 'rgba(59, 130, 246, 0.08)' : '#fff',
+                border: `1px solid ${isSelected ? '#2563eb' : '#e2e8f0'}`
+              }}
+              data-testid={`${idPrefix}-${channel.id}`}
+            >
+              <input
+                id={inputId}
+                type="checkbox"
+                checked={isSelected}
+                disabled={disabled}
+                onChange={() => handleToggle(channel.id)}
+              />
+              <div>
+                <div style={{ fontWeight: 600, fontSize: '0.95rem' }}>{label}</div>
+                <div style={{ fontSize: '0.75rem', color: '#475569' }}>{channel.target}</div>
+              </div>
+            </label>
+          )
+        })
+      )}
+    </fieldset>
+  )
+}
+

--- a/src/services/alertingService.ts
+++ b/src/services/alertingService.ts
@@ -1,0 +1,123 @@
+import axios from 'axios'
+
+const API = import.meta.env.VITE_API_BASE_URL
+
+export type NotificationChannelType = 'email' | 'slack' | 'webhook' | 'sms'
+
+export const NOTIFICATION_CHANNEL_TYPE_LABELS: Record<NotificationChannelType, string> = {
+  email: 'Email',
+  slack: 'Slack',
+  webhook: 'Webhook',
+  sms: 'SMS'
+}
+
+export type AlertOperator = 'gt' | 'gte' | 'lt' | 'lte' | 'eq' | 'neq'
+
+export type AlertWindowAggregation = 'avg' | 'max' | 'min' | 'sum'
+
+export interface AlertConditionWindow {
+  durationMinutes: number
+  aggregation: AlertWindowAggregation
+}
+
+export interface AlertCondition {
+  id?: string
+  metric: string
+  operator: AlertOperator
+  threshold: number
+  window: AlertConditionWindow
+}
+
+export interface NotificationChannel {
+  id: string
+  name: string
+  type: NotificationChannelType
+  target: string
+  metadata?: Record<string, string>
+  enabled?: boolean
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface EscalationStep {
+  delayMinutes: number
+  channelIds: string[]
+}
+
+export interface EscalationPolicy {
+  id: string
+  name: string
+  description?: string
+  steps: EscalationStep[]
+  repeat?: boolean
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface EscalationPolicyInput {
+  name: string
+  description?: string
+  steps: EscalationStep[]
+  repeat?: boolean
+}
+
+export interface RuleEscalationConfig {
+  policyId?: string
+  steps?: EscalationStep[]
+  repeat?: boolean
+}
+
+export interface AlertRule {
+  id: string
+  name: string
+  description?: string
+  severity: 'warning' | 'critical'
+  enabled: boolean
+  conditions: AlertCondition[]
+  channelIds: string[]
+  escalation?: RuleEscalationConfig | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AlertRuleInput {
+  name: string
+  description?: string
+  severity: 'warning' | 'critical'
+  enabled: boolean
+  conditions: AlertCondition[]
+  channelIds: string[]
+  escalation?: RuleEscalationConfig | null
+}
+
+export const AlertingService = {
+  async listRules() {
+    const { data } = await axios.get(`${API}/api/alerting/rules`)
+    return data as AlertRule[]
+  },
+  async createRule(input: AlertRuleInput) {
+    const { data } = await axios.post(`${API}/api/alerting/rules`, input)
+    return data as AlertRule
+  },
+  async updateRule(ruleId: string, input: AlertRuleInput) {
+    const { data } = await axios.put(`${API}/api/alerting/rules/${ruleId}`, input)
+    return data as AlertRule
+  },
+  async listChannels() {
+    const { data } = await axios.get(`${API}/api/alerting/channels`)
+    return data as NotificationChannel[]
+  },
+  async listEscalationPolicies() {
+    const { data } = await axios.get(`${API}/api/alerting/escalations`)
+    return data as EscalationPolicy[]
+  },
+  async createEscalationPolicy(input: EscalationPolicyInput) {
+    const { data } = await axios.post(`${API}/api/alerting/escalations`, input)
+    return data as EscalationPolicy
+  },
+  async updateEscalationPolicy(policyId: string, input: EscalationPolicyInput) {
+    const { data } = await axios.put(`${API}/api/alerting/escalations/${policyId}`, input)
+    return data as EscalationPolicy
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement the alerting service layer plus channel and escalation editors so monitoring alerts can be managed from the dashboard
- surface an “Alertes” tab in the monitoring dashboard with rule selection, saving, and permission messaging tied to `monitoring:manage`
- add a dedicated vitest suite for alerting flows and update the monitoring tests to wrap the dashboard in the Auth provider

## Testing
- npx vitest run src/__tests__/alerting.suite.test.tsx
- npm test -- --run *(fails: known react-router hook issues in existing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68da7a0dd7b08332aeb98fb7fa20ff35